### PR TITLE
feat: add Terraform infrastructure for GCP resources

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -133,6 +133,19 @@ scripts/                 # CLI tools
 ├── run-api.sh           # Start FastAPI server
 ├── run-dev.sh           # Start all dev services
 └── run-function.sh      # Run Cloud Function locally
+
+infra/                   # Terraform infrastructure
+├── environments/
+│   └── dev/             # Development environment
+│       ├── main.tf      # Root module
+│       ├── variables.tf
+│       ├── versions.tf
+│       ├── backend.tf   # GCS state backend
+│       └── access/      # User emails (gitignored)
+└── modules/
+    ├── apis/            # Enable GCP APIs
+    ├── iam/             # Custom roles and permissions
+    └── firestore/       # Database and indexes
 ```
 
 ### Key Dependencies
@@ -271,6 +284,15 @@ uv run pytest tests/test_recipe.py -v
 - Use Python dataclasses for all models
 - Default mutable fields with `field(default_factory=list)`
 - Add computed properties for derived values (e.g., `total_time_calculated`)
+
+### Terraform Conventions
+
+- **All infrastructure must be declared in Terraform** - no manual resource creation via console or CLI
+- **Resource names** (buckets, databases, service accounts, etc.) must be defined in `terraform.tfvars` or `variables.tf`, never hardcoded in resource blocks
+- **`gcloud` and `gsutil` commands** are only for troubleshooting, never for creating or modifying infrastructure
+- Environment-specific values go in `infra/environments/{dev,prod}/terraform.tfvars`
+- Shared module variables go in `infra/modules/*/variables.tf` with sensible defaults
+- **Free tier compliance** - All resources must stay within GCP free tier limits
 
 ## When Making Changes
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,21 +31,26 @@ coverage.xml
 *.swo
 *~
 
-# Terraform (uncomment if using)
-# *.tfstate
-# *.tfstate.*
-# *.tfvars
-# .terraform/
-# terraform.tfplan
-# terraform.tfplan.json
-# crash.log
-# crash.*.log
-# override.tf
-# override.tf.json
-# *_override.tf
-# *_override.tf.json
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform/
+.terraform.lock.hcl
+terraform.tfplan
+terraform.tfplan.json
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
 
-# GCP (uncomment if using)
+# Terraform user access files (contain personal emails)
+infra/**/access/users.txt
+
+# GCP credentials (if using service accounts locally)
 # gcloud-config/
 # service-account-key.json
 # *.json.enc

--- a/infra/environments/dev/README.md
+++ b/infra/environments/dev/README.md
@@ -1,0 +1,86 @@
+# Meal Planner Infrastructure - Development Environment
+
+This directory contains the Terraform configuration for deploying the Meal Planner infrastructure to GCP.
+
+## Prerequisites
+
+1. [Terraform](https://www.terraform.io/downloads.html) >= 1.12
+2. [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (gcloud CLI)
+3. GCP project with billing enabled
+4. User with Owner or Editor role (for initial setup)
+
+## Setup
+
+### 1. Authenticate with GCP
+
+```bash
+gcloud auth application-default login
+```
+
+### 2. Configure Variables
+
+```bash
+# Copy example config
+cp terraform.tfvars.example terraform.tfvars
+
+# Edit with your values
+# - project: Your GCP project ID
+# - region: GCP region (e.g., europe-west1)
+# - firestore_location: Firestore location (e.g., eur3)
+```
+
+### 3. Configure Backend (State Storage)
+
+Edit `backend.tf` and replace `YOUR_TFSTATE_BUCKET_NAME` with your GCS bucket name.
+
+If you don't have a state bucket, create one:
+
+```bash
+gsutil mb -l EU gs://your-unique-bucket-name
+gsutil versioning set on gs://your-unique-bucket-name
+```
+
+### 4. Add User Access
+
+Create `access/users.txt` with email addresses (one per line):
+
+```bash
+mkdir -p access
+echo "your-email@example.com" > access/users.txt
+```
+
+### 5. Initialize and Apply
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Modules
+
+| Module      | Purpose                           |
+| ----------- | --------------------------------- |
+| `apis`      | Enable required GCP APIs          |
+| `iam`       | Custom roles and user permissions |
+| `firestore` | Firestore database and indexes    |
+
+## Free Tier Limits
+
+This infrastructure stays within GCP free tier:
+
+- **Firestore**: 1 GB storage, 50K reads/day, 20K writes/day
+- **Secret Manager**: 6 active secret versions
+- **Cloud Functions**: 2M invocations/month (future use)
+- **Cloud Run**: 2M requests/month (future use)
+
+## Files
+
+| File               | Description                                |
+| ------------------ | ------------------------------------------ |
+| `main.tf`          | Root module, wires up all submodules       |
+| `variables.tf`     | Input variable definitions                 |
+| `versions.tf`      | Terraform and provider version constraints |
+| `backend.tf`       | GCS backend configuration for state        |
+| `terraform.tfvars` | Your local config (gitignored)             |
+| `access/users.txt` | User emails for IAM (gitignored)           |

--- a/infra/environments/dev/access/users.txt.example
+++ b/infra/environments/dev/access/users.txt.example
@@ -1,0 +1,7 @@
+# User emails for IAM access
+#
+# Add one email per line. Lines starting with # are comments.
+# This file is gitignored - do not commit personal emails.
+#
+# Example:
+# developer@example.com

--- a/infra/environments/dev/backend.tf
+++ b/infra/environments/dev/backend.tf
@@ -1,0 +1,16 @@
+# Backend configuration for Terraform state
+#
+# This file uses the same GCS bucket as skane-trails-checker but with a different prefix.
+# Both apps share the same GCP project.
+#
+# NOTE: The bucket name below is a placeholder. Replace with your actual bucket name.
+# You can reuse an existing state bucket or create a new one.
+
+terraform {
+  backend "gcs" {
+    # Replace with your actual bucket name
+    # If sharing a bucket with other projects, use a unique prefix
+    bucket = "YOUR_TFSTATE_BUCKET_NAME"
+    prefix = "meal-planner/terraform/state"
+  }
+}

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Meal Planner - Terraform Configuration Example
+#
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored and should NOT be committed.
+
+# GCP project ID (required)
+project = "your-gcp-project-id"
+
+# GCP region for regional resources
+region = "europe-west1"
+
+# Firestore location (multi-region recommended for durability)
+# Options: eur3 (Europe), nam5 (US), etc.
+firestore_location = "eur3"
+
+# Firestore database name for enhanced recipes
+# The (default) database is assumed to exist; this creates the secondary database
+firestore_database_name = "meal-planner"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -1,0 +1,20 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for resources"
+  type        = string
+}
+
+variable "firestore_location" {
+  description = "Firestore location ID (e.g., eur3 for multi-region Europe)"
+  type        = string
+}
+
+variable "firestore_database_name" {
+  description = "Firestore database name for enhanced recipes"
+  type        = string
+  default     = "meal-planner"
+}

--- a/infra/environments/dev/versions.tf
+++ b/infra/environments/dev/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.16.0"
+    }
+  }
+}

--- a/infra/modules/apis/main.tf
+++ b/infra/modules/apis/main.tf
@@ -1,0 +1,60 @@
+# Enable required GCP APIs for the Meal Planner application
+# This module should be called first before any other modules
+
+resource "google_project_service" "firestore" {
+  project = var.project
+  service = "firestore.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  project = var.project
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudresourcemanager" {
+  project = var.project
+  service = "cloudresourcemanager.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "iam" {
+  project = var.project
+  service = "iam.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Cloud Functions for recipe scraping
+resource "google_project_service" "cloudfunctions" {
+  project = var.project
+  service = "cloudfunctions.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudbuild" {
+  project = var.project
+  service = "cloudbuild.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "run" {
+  project = var.project
+  service = "run.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Artifact Registry for container images (Cloud Run deployments)
+resource "google_project_service" "artifactregistry" {
+  project = var.project
+  service = "artifactregistry.googleapis.com"
+
+  disable_on_destroy = false
+}

--- a/infra/modules/apis/outputs.tf
+++ b/infra/modules/apis/outputs.tf
@@ -1,0 +1,34 @@
+output "firestore_service" {
+  description = "Firestore API service resource"
+  value       = google_project_service.firestore
+}
+
+output "secretmanager_service" {
+  description = "Secret Manager API service resource"
+  value       = google_project_service.secretmanager
+}
+
+output "iam_service" {
+  description = "IAM API service resource"
+  value       = google_project_service.iam
+}
+
+output "cloudfunctions_service" {
+  description = "Cloud Functions API service resource"
+  value       = google_project_service.cloudfunctions
+}
+
+output "cloudbuild_service" {
+  description = "Cloud Build API service resource"
+  value       = google_project_service.cloudbuild
+}
+
+output "run_service" {
+  description = "Cloud Run API service resource"
+  value       = google_project_service.run
+}
+
+output "artifactregistry_service" {
+  description = "Artifact Registry API service resource"
+  value       = google_project_service.artifactregistry
+}

--- a/infra/modules/apis/variables.tf
+++ b/infra/modules/apis/variables.tf
@@ -1,0 +1,4 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}

--- a/infra/modules/firestore/main.tf
+++ b/infra/modules/firestore/main.tf
@@ -1,0 +1,125 @@
+# Firestore databases for Meal Planner
+# Two databases:
+# - (default): Original scraped recipes
+# - meal-planner: AI-enhanced recipes
+#
+# Free tier: 1 GB storage, 50K reads/day, 20K writes/day (shared across all databases)
+
+# Enhanced recipes database
+resource "google_firestore_database" "meal_planner" {
+  project     = var.project
+  name        = var.database_name
+  location_id = var.location_id
+  type        = "FIRESTORE_NATIVE"
+
+  # Free tier compatible settings
+  concurrency_mode            = "OPTIMISTIC"
+  app_engine_integration_mode = "DISABLED"
+
+  # Prevent accidental deletion of production data
+  deletion_policy = "DELETE"
+
+  depends_on = [var.firestore_api_service, var.iam_bindings_complete]
+}
+
+# Secret Manager secrets for local debugging and configuration
+resource "google_secret_manager_secret" "database_name" {
+  project   = var.project
+  secret_id = "meal-planner-database-name"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [var.secretmanager_api_service]
+}
+
+resource "google_secret_manager_secret" "project_id" {
+  project   = var.project
+  secret_id = "meal-planner-project-id"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [var.secretmanager_api_service]
+}
+
+# Secret versions with actual values
+resource "google_secret_manager_secret_version" "database_name" {
+  secret      = google_secret_manager_secret.database_name.id
+  secret_data = google_firestore_database.meal_planner.name
+}
+
+resource "google_secret_manager_secret_version" "project_id" {
+  secret      = google_secret_manager_secret.project_id.id
+  secret_data = var.project
+}
+
+# Firestore indexes for efficient querying
+
+# Recipes collection - query by cuisine, category, tags
+resource "google_firestore_index" "recipes_by_cuisine" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "recipes"
+
+  fields {
+    field_path = "cuisine"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "recipes_by_category" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "recipes"
+
+  fields {
+    field_path = "category"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "recipes_by_diet_label" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "recipes"
+
+  fields {
+    field_path = "diet_label"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+# Meal plans collection - query by week
+resource "google_firestore_index" "meal_plans_by_week" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "meal_plans"
+
+  fields {
+    field_path = "week_start"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}

--- a/infra/modules/firestore/outputs.tf
+++ b/infra/modules/firestore/outputs.tf
@@ -1,0 +1,9 @@
+output "database" {
+  description = "The Firestore database resource"
+  value       = google_firestore_database.meal_planner
+}
+
+output "database_name" {
+  description = "The Firestore database name"
+  value       = google_firestore_database.meal_planner.name
+}

--- a/infra/modules/firestore/variables.tf
+++ b/infra/modules/firestore/variables.tf
@@ -1,0 +1,30 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "database_name" {
+  description = "Firestore database name for enhanced recipes"
+  type        = string
+  default     = "meal-planner"
+}
+
+variable "location_id" {
+  description = "Firestore location ID (e.g., eur3 for multi-region Europe)"
+  type        = string
+}
+
+variable "firestore_api_service" {
+  description = "Firestore API service resource (for dependency ordering)"
+  type        = any
+}
+
+variable "secretmanager_api_service" {
+  description = "Secret Manager API service resource (for dependency ordering)"
+  type        = any
+}
+
+variable "iam_bindings_complete" {
+  description = "IAM bindings marker (for dependency ordering)"
+  type        = any
+}

--- a/infra/modules/iam/custom_roles.tf
+++ b/infra/modules/iam/custom_roles.tf
@@ -1,0 +1,126 @@
+# Custom IAM Roles for Meal Planner
+#
+# Two roles:
+# 1. Infrastructure Manager - Create and manage all infrastructure (Firestore, Secret Manager, etc.)
+# 2. App User - Runtime access to read/write data and invoke services
+
+# Infrastructure Manager Role
+# Grants permissions needed to create and manage infrastructure via Terraform
+resource "google_project_iam_custom_role" "infrastructure_manager" {
+  role_id     = "mealPlannerInfraManager"
+  title       = "Meal Planner Infrastructure Manager"
+  description = "Permissions to create and manage Firestore, Secret Manager, and related infrastructure. Used by developers during setup and CI/CD pipelines."
+
+  permissions = [
+    # Firestore/Datastore permissions
+    "datastore.databases.create",
+    "datastore.databases.delete",
+    "datastore.databases.get",
+    "datastore.databases.list",
+    "datastore.databases.update",
+    "datastore.indexes.create",
+    "datastore.indexes.delete",
+    "datastore.indexes.get",
+    "datastore.indexes.list",
+    "datastore.indexes.update",
+
+    # Secret Manager permissions
+    "secretmanager.secrets.create",
+    "secretmanager.secrets.delete",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.list",
+    "secretmanager.secrets.update",
+    "secretmanager.versions.add",
+    "secretmanager.versions.destroy",
+    "secretmanager.versions.disable",
+    "secretmanager.versions.enable",
+    "secretmanager.versions.get",
+    "secretmanager.versions.list",
+
+    # Cloud Storage permissions (for state bucket)
+    "storage.buckets.create",
+    "storage.buckets.delete",
+    "storage.buckets.get",
+    "storage.buckets.list",
+    "storage.buckets.update",
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+    "storage.objects.list",
+
+    # Cloud Run permissions (API deployment)
+    "run.services.create",
+    "run.services.delete",
+    "run.services.get",
+    "run.services.list",
+    "run.services.update",
+
+    # Cloud Functions permissions (recipe scraping)
+    "cloudfunctions.functions.create",
+    "cloudfunctions.functions.delete",
+    "cloudfunctions.functions.get",
+    "cloudfunctions.functions.list",
+    "cloudfunctions.functions.update",
+
+    # Artifact Registry permissions
+    "artifactregistry.repositories.create",
+    "artifactregistry.repositories.delete",
+    "artifactregistry.repositories.get",
+    "artifactregistry.repositories.list",
+
+    # IAM permissions (to manage user access)
+    "iam.roles.get",
+    "iam.roles.list",
+    "resourcemanager.projects.get",
+
+    # Service management
+    "serviceusage.services.enable",
+    "serviceusage.services.get",
+    "serviceusage.services.list",
+  ]
+
+  project = var.project
+
+  # Must wait for prerequisite roles to be granted
+  depends_on = [google_project_iam_binding.prerequisite_roles]
+}
+
+# App User Role
+# Grants permissions needed to run the apps and access data
+resource "google_project_iam_custom_role" "app_user" {
+  role_id     = "mealPlannerAppUser"
+  title       = "Meal Planner App User"
+  description = "Runtime permissions to read/write Firestore data, access secrets, and invoke Cloud Run/Functions. Used by app users during normal operation."
+
+  permissions = [
+    # Firestore data access
+    "datastore.entities.create",
+    "datastore.entities.delete",
+    "datastore.entities.get",
+    "datastore.entities.list",
+    "datastore.entities.update",
+    "datastore.databases.get",
+    "datastore.indexes.get",
+    "datastore.indexes.list",
+
+    # Secret Manager read access
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.list",
+    "secretmanager.versions.access",
+    "secretmanager.versions.get",
+    "secretmanager.versions.list",
+
+    # Cloud Run invoke (for API)
+    "run.services.get",
+    "run.routes.invoke",
+
+    # Cloud Functions invoke (for recipe scraping)
+    "cloudfunctions.functions.get",
+    "cloudfunctions.functions.invoke",
+  ]
+
+  project = var.project
+
+  # Must wait for prerequisite roles to be granted
+  depends_on = [google_project_iam_binding.prerequisite_roles]
+}

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -1,0 +1,56 @@
+# IAM Module - Grant permissions to users
+#
+# This module assigns custom IAM roles to users for accessing the Meal Planner project.
+# All personal user emails should be defined in environments/dev/access/users.txt
+#
+# Custom roles defined in custom_roles.tf:
+# 1. Infrastructure Manager - Create/manage infrastructure (can be revoked after setup)
+# 2. App User - Runtime data access (permanent)
+
+# Project-level IAM bindings for users
+locals {
+  # Transform user list into member format
+  user_members = [for email in var.users : "user:${email}"]
+
+  # Built-in roles needed to create custom roles
+  # These must be granted BEFORE custom roles can be created
+  prerequisite_roles = [
+    "roles/iam.roleAdmin",                   # Required to create custom IAM roles
+    "roles/resourcemanager.projectIamAdmin", # Required to grant IAM bindings
+  ]
+
+  # Custom roles to grant to all users
+  # NOTE: Infrastructure Manager role should be revoked after initial setup
+  user_roles = [
+    "projects/${var.project}/roles/mealPlannerInfraManager", # Temporary: Create/manage infrastructure
+    "projects/${var.project}/roles/mealPlannerAppUser",      # Permanent: Runtime data access
+    "roles/viewer",                                          # Read-only access to all resources
+  ]
+}
+
+# Grant prerequisite roles needed to create custom roles
+resource "google_project_iam_binding" "prerequisite_roles" {
+  for_each = length(var.users) > 0 ? toset(local.prerequisite_roles) : toset([])
+
+  project = var.project
+  role    = each.value
+  members = local.user_members
+
+  depends_on = [var.iam_api_service]
+}
+
+# Grant each role to all users
+resource "google_project_iam_binding" "user_access" {
+  for_each = length(var.users) > 0 ? toset(local.user_roles) : toset([])
+
+  project = var.project
+  role    = each.value
+  members = local.user_members
+
+  # Explicit dependencies: ensure IAM API is enabled and custom roles exist
+  depends_on = [
+    var.iam_api_service,
+    google_project_iam_custom_role.infrastructure_manager,
+    google_project_iam_custom_role.app_user,
+  ]
+}

--- a/infra/modules/iam/outputs.tf
+++ b/infra/modules/iam/outputs.tf
@@ -1,0 +1,14 @@
+output "iam_bindings_complete" {
+  description = "Marker output to ensure IAM bindings are complete before dependent resources"
+  value       = google_project_iam_binding.user_access
+}
+
+output "infrastructure_manager_role" {
+  description = "The infrastructure manager custom role"
+  value       = google_project_iam_custom_role.infrastructure_manager
+}
+
+output "app_user_role" {
+  description = "The app user custom role"
+  value       = google_project_iam_custom_role.app_user
+}

--- a/infra/modules/iam/variables.tf
+++ b/infra/modules/iam/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "users" {
+  description = "List of user email addresses to grant access to"
+  type        = list(string)
+  default     = []
+}
+
+variable "iam_api_service" {
+  description = "IAM API service resource (for dependency ordering)"
+  type        = any
+}


### PR DESCRIPTION
## Summary

Add Terraform infrastructure-as-code for deploying meal-planner to GCP, following the same patterns as skane-trails-checker.

## Changes

### Modules
- **apis**: Enable Firestore, Secret Manager, Cloud Functions, Cloud Run, Artifact Registry APIs
- **iam**: Custom roles (mealPlannerInfraManager, mealPlannerAppUser) with least-privilege permissions
- **firestore**: Database for enhanced recipes with indexes for efficient queries

### Environment (dev)
- GCS backend for state management (uses unique prefix to share bucket with other projects)
- User access via access/users.txt (gitignored)
- Example tfvars and users.txt for easy onboarding

### Documentation
- Updated copilot-instructions.md with infra structure and Terraform conventions
- Updated .gitignore for Terraform files
- Added README with setup instructions

## Free Tier Compliance

All resources stay within GCP free tier:
- Firestore: 1 GB storage, 50K reads/day, 20K writes/day
- Secret Manager: 6 active versions
- Cloud Functions/Run: 2M invocations/month (future use)

## Notes

This infrastructure is designed to work in a shared GCP project with skane-trails-checker. Each project uses unique prefixes for:
- Terraform state (meal-planner/terraform/state)
- Custom IAM roles (mealPlanner* vs skaneTrails*)
- Secret names (meal-planner-* vs firestore-*)
