### PR TITLE
fix: add python-multipart dependency for file uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN uv venv && \
     firebase-admin \
     pydantic \
     python-dotenv \
+    python-multipart \
     httpx
 
 # Stage 2: Runtime image


### PR DESCRIPTION
## Summary

Adds missing \python-multipart\ dependency to the Dockerfile. This is required by FastAPI for handling file uploads (recipe image uploads).

## Root Cause

The previous deployment was failing startup probes because FastAPI throws a runtime error when form data endpoints exist but \python-multipart\ is not installed.

## Changes

- Added \python-multipart\ to Dockerfile pip install

## Verification

- API deployed successfully
- Auth enforcement confirmed: \/api/v1/recipes\ returns 401 without token
- Health check still works: \/health\ returns 200