### PR TITLE
feat(mobile): fix OAuth web flow and add env setup scripts

### DIFF
--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -50,10 +50,6 @@ resource "google_project_iam_member" "github_actions_firebase_hosting" {
 
   depends_on = [google_service_account.github_actions_firebase]
 }
-
-# NOTE: Secret Manager access is granted per-secret in the firebase module
-# to follow least-privilege principle (not project-wide secretAccessor)
-
 # Grant prerequisite roles needed to create custom roles
 resource "google_project_iam_binding" "prerequisite_roles" {
   for_each = length(var.users) > 0 ? toset(local.prerequisite_roles) : toset([])

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,6 +3,12 @@
  * Sets up providers and global configuration.
  */
 
+// IMPORTANT: This must be called before any other imports to properly handle
+// OAuth popup callbacks on web. It closes the popup window when returning from
+// the auth provider.
+import * as WebBrowser from 'expo-web-browser';
+WebBrowser.maybeCompleteAuthSession();
+
 import React, { useEffect } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 import { Stack } from 'expo-router';

--- a/mobile/scripts/setup-env.ps1
+++ b/mobile/scripts/setup-env.ps1
@@ -1,0 +1,73 @@
+# Fetch secrets from Google Cloud Secret Manager and create .env file
+#
+# Usage:
+#   .\scripts\setup-env.ps1
+#
+# Prerequisites:
+#   - gcloud CLI authenticated
+#   - Access to the hikes-482104 project secrets
+
+param(
+    [string]$ProjectId = "hikes-482104"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "🔐 Fetching secrets from Google Cloud Secret Manager..." -ForegroundColor Cyan
+
+# Function to fetch a secret
+function Get-Secret {
+    param([string]$SecretName)
+    try {
+        $value = gcloud secrets versions access latest --secret=$SecretName --project=$ProjectId 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  ⚠️  Secret '$SecretName' not found, skipping" -ForegroundColor Yellow
+            return $null
+        }
+        return $value
+    } catch {
+        Write-Host "  ⚠️  Failed to fetch '$SecretName': $_" -ForegroundColor Yellow
+        return $null
+    }
+}
+
+# Fetch all secrets
+$secrets = @{
+    "EXPO_PUBLIC_API_URL" = Get-Secret "github_EXPO_PUBLIC_API_URL"
+    "EXPO_PUBLIC_FIREBASE_API_KEY" = Get-Secret "github_EXPO_PUBLIC_FIREBASE_API_KEY"
+    "EXPO_PUBLIC_FIREBASE_APP_ID" = Get-Secret "github_EXPO_PUBLIC_FIREBASE_APP_ID"
+    "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID" = Get-Secret "github_EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"
+    "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" = Get-Secret "meal-planner_oauth_client_id"
+}
+
+# Derived values (not in Secret Manager)
+$firebaseProjectId = "hikes-482104"
+
+Write-Host ""
+Write-Host "📝 Creating .env file..." -ForegroundColor Cyan
+
+$envContent = @"
+# API endpoint (use localhost for local backend, or Cloud Run URL for production)
+# To use local backend, change to: http://localhost:8000
+EXPO_PUBLIC_API_URL=$($secrets["EXPO_PUBLIC_API_URL"] ?? "http://localhost:8000")
+
+# Firebase config
+EXPO_PUBLIC_FIREBASE_API_KEY=$($secrets["EXPO_PUBLIC_FIREBASE_API_KEY"])
+EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=${firebaseProjectId}.firebaseapp.com
+EXPO_PUBLIC_FIREBASE_PROJECT_ID=${firebaseProjectId}
+EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=${firebaseProjectId}.firebasestorage.app
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=$($secrets["EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"])
+EXPO_PUBLIC_FIREBASE_APP_ID=$($secrets["EXPO_PUBLIC_FIREBASE_APP_ID"])
+
+# Google OAuth Client IDs (for Google Sign-In)
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$($secrets["EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID"])
+"@
+
+$envPath = Join-Path $PSScriptRoot ".." ".env"
+$envContent | Out-File -FilePath $envPath -Encoding utf8 -NoNewline
+
+Write-Host ""
+Write-Host "✅ Created .env file at: $envPath" -ForegroundColor Green
+Write-Host ""
+Write-Host "📝 Note: API URL is set to production. For local development, edit .env:" -ForegroundColor Yellow
+Write-Host "   EXPO_PUBLIC_API_URL=http://localhost:8000"

--- a/mobile/scripts/setup-env.sh
+++ b/mobile/scripts/setup-env.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Fetch secrets from Google Cloud Secret Manager and create .env file
+#
+# Usage:
+#   ./scripts/setup-env.sh
+#
+# Prerequisites:
+#   - gcloud CLI authenticated
+#   - Access to the hikes-482104 project secrets
+
+set -e
+
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-hikes-482104}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+echo "🔐 Fetching secrets from Google Cloud Secret Manager..."
+
+# Function to fetch a secret
+get_secret() {
+    local secret_name="$1"
+    local value
+    if value=$(gcloud secrets versions access latest --secret="$secret_name" --project="$PROJECT_ID" 2>/dev/null); then
+        echo "$value"
+    else
+        echo "  ⚠️  Secret '$secret_name' not found, skipping" >&2
+        echo ""
+    fi
+}
+
+# Fetch all secrets
+EXPO_PUBLIC_API_URL=$(get_secret "github_EXPO_PUBLIC_API_URL")
+EXPO_PUBLIC_FIREBASE_API_KEY=$(get_secret "github_EXPO_PUBLIC_FIREBASE_API_KEY")
+EXPO_PUBLIC_FIREBASE_APP_ID=$(get_secret "github_EXPO_PUBLIC_FIREBASE_APP_ID")
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=$(get_secret "github_EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID")
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$(get_secret "meal-planner_oauth_client_id")
+
+# Derived values (not in Secret Manager)
+FIREBASE_PROJECT_ID="hikes-482104"
+
+# Default API URL to localhost if not set
+if [ -z "$EXPO_PUBLIC_API_URL" ]; then
+    EXPO_PUBLIC_API_URL="http://localhost:8000"
+fi
+
+echo ""
+echo "📝 Creating .env file..."
+
+cat > "$ENV_FILE" << EOF
+# API endpoint (use localhost for local backend, or Cloud Run URL for production)
+# To use local backend, change to: http://localhost:8000
+EXPO_PUBLIC_API_URL=${EXPO_PUBLIC_API_URL}
+
+# Firebase config
+EXPO_PUBLIC_FIREBASE_API_KEY=${EXPO_PUBLIC_FIREBASE_API_KEY}
+EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=${FIREBASE_PROJECT_ID}.firebaseapp.com
+EXPO_PUBLIC_FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
+EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=${FIREBASE_PROJECT_ID}.firebasestorage.app
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=${EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID}
+EXPO_PUBLIC_FIREBASE_APP_ID=${EXPO_PUBLIC_FIREBASE_APP_ID}
+
+# Google OAuth Client IDs (for Google Sign-In)
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=${EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID}
+EOF
+
+echo ""
+echo "✅ Created .env file at: $ENV_FILE"
+echo ""
+echo "📝 Note: API URL is set to production. For local development, edit .env:"
+echo "   EXPO_PUBLIC_API_URL=http://localhost:8000"


### PR DESCRIPTION
## Summary
Fix Google OAuth authentication flow for web platform.

## Changes
- **Move \WebBrowser.maybeCompleteAuthSession()\** to \_layout.tsx\ before any imports - this is critical for handling OAuth popup callbacks on web
- **Add \esponseType: 'id_token'\** to Google.useAuthRequest() - required for Firebase Auth on web
- **Add debug logging** for OAuth redirect URI and response params to help troubleshoot auth issues
- **Add setup-env scripts** (\setup-env.ps1\ and \setup-env.sh\) to fetch secrets from Google Cloud Secret Manager for local development
- Clean up redundant comment in IAM module

## Testing
- [ ] OAuth login works on web (Firebase Hosting)
- [ ] OAuth login works locally on web
- [ ] OAuth login works on mobile (if applicable)