### PR TITLE
fix(mobile): prevent redirect during OAuth callback processing

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -5,16 +5,28 @@
  */
 
 import React from 'react';
-import { View, ActivityIndicator } from 'react-native';
+import { View, ActivityIndicator, Platform } from 'react-native';
 import { Tabs, Redirect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@/lib/hooks/use-auth';
+
+// Check if this appears to be an OAuth callback (has auth params in URL)
+function isOAuthCallback(): boolean {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') {
+    return false;
+  }
+  const hash = window.location.hash;
+  const search = window.location.search;
+  return hash.includes('id_token=') || hash.includes('access_token=') ||
+         search.includes('code=') || search.includes('state=');
+}
 
 export default function TabLayout() {
   const { user, loading } = useAuth();
 
   // Show loading spinner while checking auth state
-  if (loading) {
+  // Also show loading if this might be an OAuth callback being processed
+  if (loading || isOAuthCallback()) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'white' }}>
         <ActivityIndicator size="large" color="#10b981" />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -7,7 +7,23 @@
 // OAuth popup callbacks on web. It closes the popup window when returning from
 // the auth provider.
 import * as WebBrowser from 'expo-web-browser';
-WebBrowser.maybeCompleteAuthSession();
+import { Platform } from 'react-native';
+
+// On web, check if this is an OAuth callback popup BEFORE React renders.
+// If maybeCompleteAuthSession succeeds, the popup will close and we don't need to render.
+if (Platform.OS === 'web' && typeof window !== 'undefined') {
+  const result = WebBrowser.maybeCompleteAuthSession();
+  console.log('maybeCompleteAuthSession result:', result);
+  console.log('Current URL:', window.location.href);
+  console.log('Has opener:', !!window.opener);
+
+  // If this is a successful OAuth callback, the popup should close.
+  // If it doesn't close immediately, we might need to prevent the redirect.
+  if (result.type === 'success' && window.opener) {
+    // Popup handled - prevent further rendering
+    console.log('OAuth callback handled, popup should close');
+  }
+}
 
 import React, { useEffect } from 'react';
 import { AppState, AppStateStatus } from 'react-native';


### PR DESCRIPTION
## Problem
OAuth popup was redirecting to /sign-in before maybeCompleteAuthSession() could process the callback and close the popup.

## Root Cause
When Google redirects back to \https://hikes-482104.web.app#id_token=...\:
1. The app loads and the tabs layout checks if user is authenticated
2. No user yet (OAuth not processed), so it redirects to \/sign-in\
3. This loses the hash fragment with the OAuth token
4. maybeCompleteAuthSession() runs but has no token to process

## Solution
- Add \isOAuthCallback()\ check in tabs layout to detect OAuth params in URL
- Show loading spinner instead of redirecting when OAuth callback is detected
- This gives maybeCompleteAuthSession() time to process the callback and close the popup

## Testing
- [ ] OAuth login works on production Firebase Hosting
- [ ] OAuth popup closes correctly after Google sign-in
- [ ] Normal auth redirect still works when not an OAuth callback