### PR TITLE
fix(mobile): add skipRedirectCheck to maybeCompleteAuthSession

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -12,15 +12,15 @@ import { Platform } from 'react-native';
 // On web, check if this is an OAuth callback popup BEFORE React renders.
 // If maybeCompleteAuthSession succeeds, the popup will close and we don't need to render.
 if (Platform.OS === 'web' && typeof window !== 'undefined') {
-  const result = WebBrowser.maybeCompleteAuthSession();
+  // skipRedirectCheck: true is needed because the URL may have hash fragments
+  // that don't exactly match the registered redirect URI
+  const result = WebBrowser.maybeCompleteAuthSession({ skipRedirectCheck: true });
   console.log('maybeCompleteAuthSession result:', result);
   console.log('Current URL:', window.location.href);
   console.log('Has opener:', !!window.opener);
 
   // If this is a successful OAuth callback, the popup should close.
-  // If it doesn't close immediately, we might need to prevent the redirect.
-  if (result.type === 'success' && window.opener) {
-    // Popup handled - prevent further rendering
+  if (result.type === 'success') {
     console.log('OAuth callback handled, popup should close');
   }
 }


### PR DESCRIPTION
## Problem
OAuth popup shows spinner but doesn't close. The \maybeCompleteAuthSession()\ returns \{type: 'failed', message: 'No auth session is currently in progress'}\ even though the URL clearly contains \#state=...&id_token=...\

## Root Cause
The default behavior of \maybeCompleteAuthSession()\ checks that the current URL exactly matches the registered redirect URI. The hash fragment with OAuth params causes this check to fail.

## Solution
Add \skipRedirectCheck: true\ to bypass the strict redirect URI matching.

This is safe because the real OAuth security comes from:
1. **Google's redirect URI validation** - Google only redirects to URIs registered in Cloud Console
2. **The state parameter** - CSRF token that must match (still validated)
3. **The id_token signature** - Cryptographically signed by Google (still validated)

## Testing
- [ ] OAuth popup closes after Google sign-in
- [ ] User is authenticated after popup closes