### PR TITLE
fix(mobile): use Firebase signInWithPopup for web auth

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -5,28 +5,16 @@
  */
 
 import React from 'react';
-import { View, ActivityIndicator, Platform } from 'react-native';
+import { View, ActivityIndicator } from 'react-native';
 import { Tabs, Redirect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@/lib/hooks/use-auth';
-
-// Check if this appears to be an OAuth callback (has auth params in URL)
-function isOAuthCallback(): boolean {
-  if (Platform.OS !== 'web' || typeof window === 'undefined') {
-    return false;
-  }
-  const hash = window.location.hash;
-  const search = window.location.search;
-  return hash.includes('id_token=') || hash.includes('access_token=') ||
-         search.includes('code=') || search.includes('state=');
-}
 
 export default function TabLayout() {
   const { user, loading } = useAuth();
 
   // Show loading spinner while checking auth state
-  // Also show loading if this might be an OAuth callback being processed
-  if (loading || isOAuthCallback()) {
+  if (loading) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'white' }}>
         <ActivityIndicator size="large" color="#10b981" />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,27 +3,9 @@
  * Sets up providers and global configuration.
  */
 
-// IMPORTANT: This must be called before any other imports to properly handle
-// OAuth popup callbacks on web. It closes the popup window when returning from
-// the auth provider.
-import * as WebBrowser from 'expo-web-browser';
-import { Platform } from 'react-native';
-
-// On web, check if this is an OAuth callback popup BEFORE React renders.
-// If maybeCompleteAuthSession succeeds, the popup will close and we don't need to render.
-if (Platform.OS === 'web' && typeof window !== 'undefined') {
-  // skipRedirectCheck: true is needed because the URL may have hash fragments
-  // that don't exactly match the registered redirect URI
-  const result = WebBrowser.maybeCompleteAuthSession({ skipRedirectCheck: true });
-  console.log('maybeCompleteAuthSession result:', result);
-  console.log('Current URL:', window.location.href);
-  console.log('Has opener:', !!window.opener);
-
-  // If this is a successful OAuth callback, the popup should close.
-  if (result.type === 'success') {
-    console.log('OAuth callback handled, popup should close');
-  }
-}
+// NOTE: For web, we use Firebase's native signInWithPopup which handles popup
+// communication correctly. The expo-web-browser maybeCompleteAuthSession is only
+// needed for native platforms using expo-auth-session.
 
 import React, { useEffect } from 'react';
 import { AppState, AppStateStatus } from 'react-native';


### PR DESCRIPTION
## Problem
The expo-auth-session popup flow doesn't work on web because \window.opener\ is lost when the full React app loads in the popup window. This caused the popup to never close and auth to fail with 'No auth session is currently in progress'.

## Solution
Use platform-specific auth strategies:
- **Web**: Firebase's native \signInWithPopup\ which handles popup communication correctly
- **Native (iOS/Android)**: Continue using expo-auth-session

## Changes
- **use-auth.tsx**: Platform-specific auth - \signInWithPopup\ for web, expo-auth-session for native
- **_layout.tsx**: Remove expo-web-browser \maybeCompleteAuthSession\ (not needed for web anymore)
- **(tabs)/_layout.tsx**: Remove OAuth callback detection (Firebase popup doesn't redirect to app URL)

## Testing
- Sign in with Google on web should now work correctly
- Popup opens, user signs in, popup closes, user is authenticated