### PR TITLE
fix: load Ionicons font explicitly for web compatibility

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -11,17 +11,35 @@ import React, { useEffect } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useFonts } from 'expo-font';
+import { Ionicons } from '@expo/vector-icons';
+import * as SplashScreen from 'expo-splash-screen';
 import { QueryProvider, restoreQueryCache, persistQueryCache } from '@/lib/query-provider';
 import { EnhancedModeProvider } from '@/lib/enhanced-mode-context';
 import { SettingsProvider } from '@/lib/settings-context';
 import { AuthProvider } from '@/lib/hooks/use-auth';
 import '../global.css';
 
+// Prevent splash screen from auto-hiding until fonts are loaded
+SplashScreen.preventAutoHideAsync();
+
 export default function RootLayout() {
+  // Load Ionicons font for web compatibility
+  const [fontsLoaded] = useFonts({
+    ...Ionicons.font,
+  });
+
   // Restore cache on app startup
   useEffect(() => {
     restoreQueryCache();
   }, []);
+
+  // Hide splash screen once fonts are loaded
+  useEffect(() => {
+    if (fontsLoaded) {
+      SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded]);
 
   // Persist cache when app goes to background
   useEffect(() => {
@@ -34,6 +52,11 @@ export default function RootLayout() {
     const subscription = AppState.addEventListener('change', handleAppStateChange);
     return () => subscription.remove();
   }, []);
+
+  // Don't render until fonts are loaded
+  if (!fontsLoaded) {
+    return null;
+  }
 
   return (
     <AuthProvider>


### PR DESCRIPTION
Fixes font loading issue on Firebase Hosting where Ionicons TTF files were not being bundled in the static export.

## Changes
- Use useFonts hook to explicitly load Ionicons font
- Prevent app render until fonts are loaded
- Properly integrate with splash screen

## Problem
The Expo static web build was not including Ionicons fonts in the output, causing OTS parsing errors. This happened because Firebase Hosting rewrite rule returned index.html for missing font files.