### PR TITLE
fix: update setup-node action to v6.2.0

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@cdcab5eeda1f8cafde30020a865ad99ccb81baed # v5.0.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
The previous SHA \cdcab5eeda1f8cafde30020a865ad99ccb81baed\ was invalid/nonexistent, causing deploy failures on push to main and manual trigger.

Updated to v6.2.0 with correct SHA \6044e13b5dc448c55e2357c09f80417699197238\.