### PR TITLE
fix(infra): preserve storage bucket region + add migration scripts

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -165,6 +165,7 @@ module "storage" {
 
   project     = var.project
   bucket_name = var.recipe_images_bucket_name
+  location    = var.region # Keep in same region as other resources
 
   # Allow CORS from any origin (mobile and web apps)
   cors_origins = ["*"]


### PR DESCRIPTION
## Summary

Fixes terraform plan drift that would have recreated the storage bucket (losing all recipe images).

### Changes

- **infra/environments/dev/main.tf**: Add \location = var.region\ to storage module to match existing bucket's \urope-west1\ location
- **scripts/check_db.py**: Database migration script with original↔enhanced recipe linking
- **scripts/check_id.py**: Helper to verify enhanced counts across databases  
- **scripts/consolidate_databases.py**: Updated with explicit project ID

### Background

The storage module default location was \US\ but the deployed bucket is in \urope-west1\. Without this fix, \	erraform apply\ would:
- Destroy \hikes-482104-recipe-images\ bucket (with all images!)
- Recreate it in US region

The \	erraform.tfvars\ (gitignored) was also updated locally to set \ecipe_images_bucket_name\.

### Terraform Plan (after fix)

\\\
Plan: 0 to add, 0 to change, 11 to destroy.
\\\

Only destroys obsolete \llowed_users\ Firestore documents (old auth config, replaced by \superusers\ collection).