### PR TITLE
refactor(ci): use GCP Secret Manager instead of GitHub secrets

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -30,7 +30,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-provider
           service_account: github-actions-firebase@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
 
       - name: Setup Node.js


### PR DESCRIPTION
Replaces most GitHub secrets with GCP Secret Manager lookups in the Firebase Hosting deployment workflow.

**Changes:**
- Fetch EXPO_PUBLIC_* secrets from GCP Secret Manager (Terraform-managed)
- Only GCP_PROJECT_ID and GCP_PROJECT_NUMBER remain as GitHub secrets
- Derive Firebase auth domain, project ID, and storage bucket from project ID

**Why:** The Cloud Run service URL changed, but the GitHub secret wasn't updated, causing 401/403/404 errors in production. With this change, Terraform keeps the secrets in sync automatically.