### PR TITLE
fix: compute CORS origins from Terraform outputs instead of hardcoding

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -58,6 +58,4 @@ jobs:
           gcloud run deploy ${{ env.SERVICE_NAME }} \
             --image "${{ env.IMAGE }}" \
             --region ${{ env.REGION }} \
-            --platform managed \
-            --allow-unauthenticated \
-            --set-env-vars "GCP_PROJECT_ID=${{ env.GCP_PROJECT_ID }}"
+            --platform managed

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -143,7 +143,13 @@ module "cloud_run" {
   service_name       = "meal-planner-api"
   image_url          = "${module.artifact_registry.repository_url}/api:latest"
   firestore_database = var.firestore_database_name
-  allowed_origins    = var.cloud_run_allowed_origins
+  allowed_origins    = join(",", [
+    module.firebase.hosting_url,
+    "https://${var.project}.firebaseapp.com",
+    "http://localhost:8081",
+    "http://localhost:19006",
+    "http://localhost:3000",
+  ])
   gcs_bucket_name    = module.storage.bucket_name
 
   # Allow public access - Firebase Auth is validated in application code

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -25,12 +25,6 @@ variable "firebase_authorized_domains" {
   default     = []
 }
 
-variable "cloud_run_allowed_origins" {
-  description = "Comma-separated list of allowed CORS origins for Cloud Run API"
-  type        = string
-  default     = ""
-}
-
 # OAuth secrets - created by scripts/create-oauth-client.ps1 or .sh
 # Set to true after running the script
 variable "oauth_secrets_exist" {


### PR DESCRIPTION
## Problem

After merging the database consolidation PR (#128), the production site broke with CORS 400 errors. The Cloud Run deploy workflow was using `--set-env-vars` which **replaces all env vars** on every deploy, wiping out Terraform-managed config including `ALLOWED_ORIGINS`, `GOOGLE_CLOUD_PROJECT`, `FIRESTORE_DATABASE`, and `GOOGLE_API_KEY`.

Additionally, the CORS origins were hardcoded in `terraform.tfvars` with the project ID, which shouldn't be in the repo.

## Fix

### Deploy workflow (`cloud-run-deploy.yml`)
- Removed `--set-env-vars "GCP_PROJECT_ID=..."` — was overwriting all Terraform-managed env vars on every deploy
- Removed `--allow-unauthenticated` — public access is managed by Terraform IAM policy

### Terraform (`infra/environments/dev/`)
- Removed `cloud_run_allowed_origins` variable (was hardcoded with project ID in tfvars)
- Compute `allowed_origins` from `module.firebase.hosting_url` + `${var.project}.firebaseapp.com` + localhost dev ports
- Works for any GCP project without hardcoding

## Verification

- `terraform apply` succeeded — CORS env vars restored on Cloud Run
- Site is working again
