### PR TITLE
fix: prevent 403 for non-superuser members viewing recipes

### DIFF
--- a/mobile/app/(tabs)/recipe/[id].tsx
+++ b/mobile/app/(tabs)/recipe/[id].tsx
@@ -376,7 +376,7 @@ export default function RecipeDetailScreen() {
 
   // Household data for superuser transfer feature
   const isSuperuser = currentUser?.role === 'superuser';
-  const { data: households } = useHouseholds();
+  const { data: households } = useHouseholds({ enabled: isSuperuser });
   const transferRecipe = useTransferRecipe();
 
   // Initialize edit form when opening modal

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -18,6 +18,7 @@ import { shadows, borderRadius, colors, spacing, fontSize, fontWeight, fontFamil
 import { useSettings, LANGUAGES, type AppLanguage } from '@/lib/settings-context';
 import { showNotification } from '@/lib/alert';
 import { useAuth } from '@/lib/hooks/use-auth';
+import { useCurrentUser } from '@/lib/hooks/use-admin';
 import { GradientBackground } from '@/components';
 
 // Common items that people often have at home
@@ -77,6 +78,7 @@ function SectionHeader({
 export default function SettingsScreen() {
   const router = useRouter();
   const { user, signOut } = useAuth();
+  const { data: currentUser } = useCurrentUser();
   const { settings, addItemAtHome, removeItemAtHome, setLanguage } = useSettings();
   const [newItem, setNewItem] = useState('');
 
@@ -166,13 +168,19 @@ export default function SettingsScreen() {
             />
 
             <Pressable
-              onPress={() => router.push('/household-settings')}
+              onPress={() => {
+                if (currentUser?.household_id) {
+                  router.push(`/household-settings?id=${currentUser.household_id}`);
+                }
+              }}
+              disabled={!currentUser?.household_id}
               style={({ pressed }) => ({
                 flexDirection: 'row',
                 alignItems: 'center',
                 backgroundColor: pressed ? colors.bgDark : colors.glass.card,
                 borderRadius: borderRadius.md,
                 padding: spacing.lg,
+                opacity: currentUser?.household_id ? 1 : 0.5,
                 ...shadows.sm,
               })}
             >

--- a/mobile/lib/hooks/use-admin.ts
+++ b/mobile/lib/hooks/use-admin.ts
@@ -42,11 +42,12 @@ export function useCurrentUser(options?: { enabled?: boolean }) {
 /**
  * Get all households (superuser only).
  */
-export function useHouseholds() {
+export function useHouseholds(options?: { enabled?: boolean }) {
   return useQuery<Household[]>({
     queryKey: adminKeys.households(),
     queryFn: () => api.getHouseholds(),
     retry: false,
+    enabled: options?.enabled ?? true,
   });
 }
 


### PR DESCRIPTION
## Problem

Regular (non-superuser) members get signed out when clicking a recipe in production. They see a popup: *"Your account is not part of any household"* and are redirected to the login screen.

## Root Cause

recipe/[id].tsx calls useHouseholds() unconditionally on every recipe detail page load. This hits GET /api/v1/admin/households which requires **superuser** access. For regular members (role: member), the API returns **403**, which triggers the global onUnauthorized handler — signing them out.

Cloud Run logs confirmed all 403s were on /api/v1/admin/households.

## Fix

### 1. Guard useHouseholds with superuser check (the production fix)
- useHouseholds hook now accepts { enabled } option
- Recipe page passes { enabled: isSuperuser } — query only fires for superusers

### 2. Fix household-settings navigation (separate bug)
- Settings page navigated to /household-settings without passing the id query parameter
- Household-settings page requires id from URL params, showed "Invalid household ID" without it
- Now uses useCurrentUser() to get household_id and passes it as ?id=
- Button disabled when no household assigned

## Files Changed
- mobile/app/(tabs)/recipe/[id].tsx — guard useHouseholds with enabled: isSuperuser
- mobile/lib/hooks/use-admin.ts — add enabled option to useHouseholds
- mobile/app/(tabs)/settings.tsx — pass household_id to household-settings navigation
