### PR TITLE
chore: organize instruction files and add applyTo frontmatter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@
 3. Skim Failure Tracking table for patterns relevant to current topic
 4. Acknowledge what you found before proceeding
 
-This file persists across conversations. Ignoring it loses track of work.
+This file is gitignored (local-only, never committed). Ignoring it loses track of work.
 
 **On failure:** Log to Failure Tracking table in `.copilot-tasks.md`; when count reaches 3, promote to permanent documentation.
 
@@ -17,7 +17,7 @@ This file persists across conversations. Ignoring it loses track of work.
 | | `.copilot-tasks.md` | `manage_todo_list` tool |
 |---|---|---|
 | **Purpose** | Persistent project backlog across conversations | Ephemeral progress tracker within a single session |
-| **Lifetime** | Permanent — committed to repo | Gone when conversation ends |
+| **Lifetime** | Permanent — local file (gitignored) | Gone when conversation ends |
 | **Content** | Open issues, deferred work, failure tracking | Steps for the current task only |
 | **When to update** | Branch changes, tasks complete, issues discovered | Breaking down multi-step work in progress |
 

--- a/.github/instructions/firestore.instructions.md
+++ b/.github/instructions/firestore.instructions.md
@@ -1,3 +1,8 @@
+---
+applyTo: "**/*.py"
+description: "Firestore schema conventions for meal planner"
+---
+
 # Firestore Instructions
 
 These conventions apply when working with Firestore data in this project.

--- a/.github/instructions/python-style-guide.instructions.md
+++ b/.github/instructions/python-style-guide.instructions.md
@@ -1,0 +1,278 @@
+---
+applyTo: "**/*.py"
+---
+
+# Python Style Guide
+
+## Core Principles
+
+Write code that is self-documenting, maintainable, and follows modern Python best practices. Prioritize readability and explicitness over cleverness.
+
+## File Organization
+
+### Size Limits
+
+- **Maximum 500 lines per module**
+- **Maximum 50 lines per function/method**
+- When approaching limits, extract related functionality into separate modules
+- Split large modules by logical domain boundaries (models, services, utilities)
+
+### Module Structure
+
+```python
+"""Module docstring explaining purpose."""
+
+# 1. Standard library imports
+from typing import Any
+import json
+
+# 2. Third-party imports
+from pydantic import BaseModel
+from google.cloud import firestore
+
+# 3. Local imports
+from api.models import Recipe
+from api.services import parser
+
+# 4. Constants
+MAX_RETRIES = 3
+DEFAULT_TIMEOUT = 30
+
+# 5. Classes and functions
+class RecipeService:
+    ...
+
+def parse_ingredients(text: str) -> list[str]:
+    ...
+```
+
+### When to Split Files
+
+- Multiple unrelated classes in one file → separate by class
+- Helper functions >100 lines total → extract to `utils.py` or domain-specific module
+- Mixed concerns (models + business logic) → separate into `models/` and `services/`
+- Deeply nested packages → keep to 2-3 levels maximum
+
+## Code Structure
+
+### Type Hints
+
+- **Required on all function signatures** (parameters and return types)
+- Use modern syntax: `list[str]` not `List[str]`, `dict[str, Any]` not `Dict[str, Any]`
+- For complex types, use type aliases:
+
+```python
+RecipeDict = dict[str, Any]
+IngredientList = list[str]
+
+def parse_recipe(data: RecipeDict) -> IngredientList:
+    ...
+```
+
+### Dataclasses Over Dictionaries
+
+- Use `@dataclass` for structured data
+- Use `field(default_factory=list)` for mutable defaults
+- Add computed properties with `@property` decorator
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class Recipe:
+    title: str
+    ingredients: list[str] = field(default_factory=list)
+    servings: int = 4
+
+    @property
+    def ingredient_count(self) -> int:
+        return len(self.ingredients)
+```
+
+### Functions
+
+- **Single responsibility** - one function does one thing
+- **Maximum 50 lines** - extract helper functions if longer
+- **Avoid side effects** - pure functions where possible
+- **Early returns** for guard clauses:
+
+```python
+def process_recipe(recipe_id: str | None) -> Recipe | None:
+    if recipe_id is None:
+        return None
+
+    if not recipe_id.isdigit():
+        return None
+
+    # Main logic here
+    return fetch_recipe(recipe_id)
+```
+
+### Error Handling
+
+- **Explicit exception types** - catch specific exceptions, not bare `except:`
+- **Fail fast** - validate inputs early, raise exceptions for invalid state
+- **Let exceptions propagate** unless you can meaningfully handle them
+- Use custom exceptions for domain errors:
+
+```python
+class RecipeNotFoundError(Exception):
+    """Raised when recipe doesn't exist in database."""
+    pass
+
+def get_recipe(recipe_id: str) -> Recipe:
+    recipe = db.get(recipe_id)
+    if recipe is None:
+        raise RecipeNotFoundError(f"Recipe {recipe_id} not found")
+    return recipe
+```
+
+### Async/Await
+
+- Default to **sync** unless I/O-bound operations require async
+- When using async, be consistent - don't mix sync and async in same module
+- Use `asyncio.gather()` for parallel async operations
+- Mark async functions clearly: `async def fetch_recipe(...)`
+
+## Naming Conventions
+
+- **Modules**: `snake_case.py` (e.g., `recipe_parser.py`)
+- **Classes**: `PascalCase` (e.g., `RecipeService`)
+- **Functions/variables**: `snake_case` (e.g., `parse_ingredients`)
+- **Constants**: `UPPER_SNAKE_CASE` (e.g., `MAX_RETRIES`)
+- **Private members**: `_leading_underscore` (e.g., `_internal_helper`)
+- **Boolean variables**: Use verb prefixes (`is_valid`, `has_image`, `can_edit`)
+
+## Documentation
+
+### Docstrings
+
+- **Google style** for consistency
+- **Required for**:
+  - Public classes (purpose, attributes)
+  - Public functions (what it does, args, returns, raises)
+  - Modules (top-level purpose)
+- **Not required for**:
+  - Private functions (if name is self-explanatory)
+  - Simple property getters
+  - Dataclass fields (use inline type comments if needed)
+
+```python
+def parse_ingredients(text: str, servings: int = 4) -> list[str]:
+    """Parse ingredient text into structured list.
+
+    Args:
+        text: Raw ingredient text from recipe
+        servings: Number of servings to scale for
+
+    Returns:
+        List of parsed ingredient strings
+
+    Raises:
+        ValueError: If text is empty or servings < 1
+    """
+    ...
+```
+
+### Comments
+
+- **Avoid inline comments** - code should be self-documenting
+- **When necessary**: Explain _why_, not _what_
+- **Acceptable use cases**:
+  - Non-obvious algorithmic choices
+  - Workarounds for external API quirks
+  - TODO markers (with ticket reference): `# TODO(#123): Fix edge case`
+
+## Testing
+
+### Test File Organization
+
+- Mirror source structure: `api/services/parser.py` → `tests/test_parser.py`
+- Group related tests in classes: `class TestIngredientParser:`
+- Test file naming: `test_*.py`
+
+### Test Structure
+
+- **Arrange-Act-Assert** pattern
+- **One assertion per test** (where practical)
+- **Descriptive names**: `test_parse_ingredients_with_fractions_converts_to_decimal`
+- **Use fixtures** for common setup (pytest fixtures)
+- **Mock external services** - never call real APIs in tests
+
+```python
+def test_parse_ingredients_handles_empty_input():
+    """Should return empty list when given empty string."""
+    result = parse_ingredients("")
+    assert result == []
+
+def test_parse_ingredients_extracts_quantities():
+    """Should extract numeric quantities from ingredient text."""
+    result = parse_ingredients("2 cups flour")
+    assert result[0].quantity == 2
+    assert result[0].unit == "cups"
+```
+
+## Code Smells to Avoid
+
+- **Long parameter lists** (>4 params) → use dataclass or kwargs dict
+- **Deeply nested conditionals** (>3 levels) → extract to helper functions
+- **Duplicate code blocks** (>10 lines) → extract to shared function
+- **God classes** (>300 lines) → split by responsibility
+- **Magic numbers** → extract to named constants
+- **Mutable default arguments** → use `None` and assign inside function
+- **Global state** → use dependency injection or explicit parameters
+
+## Separation of Concerns
+
+### Models (`models/`)
+
+- Data structures only (dataclasses, Pydantic models)
+- No business logic
+- Validation rules (via Pydantic validators)
+
+### Services (`services/`)
+
+- Business logic and orchestration
+- Interact with external APIs, databases
+- Return models, raise domain exceptions
+
+### Routers (`routers/`)
+
+- HTTP request/response handling
+- Input validation (basic)
+- Call services, return JSON
+
+### Storage (`storage/`)
+
+- Database operations only
+- CRUD operations on Firestore/database
+- Return models or None
+
+## Dependencies
+
+- **Minimize external dependencies** - prefer standard library when sufficient
+- **Pin versions** in `pyproject.toml`
+- **Group by purpose** (dev, test, production)
+- **Document why** - add comment for non-obvious dependencies
+
+## Refactoring Triggers
+
+When you encounter these patterns, refactor immediately:
+
+- Function exceeds 50 lines → extract helpers
+- Module exceeds 500 lines → split by domain
+- Duplicate logic in 3+ places → create shared function
+- Class has >10 methods → split into multiple classes
+- Conditional complexity >3 levels → extract to functions
+- Test setup >20 lines → create fixture or factory
+
+## Pre-Commit Checklist
+
+- [ ] Ruff passes: `uv run ruff check`
+- [ ] Tests pass: `uv run pytest --cov=api`
+- [ ] Type hints on all new functions
+- [ ] Docstrings on all public functions/classes
+- [ ] No magic numbers (extract to constants)
+- [ ] No duplicate code blocks >10 lines
+- [ ] File size <500 lines
+- [ ] Function size <50 lines

--- a/.github/instructions/terraform.instructions.md
+++ b/.github/instructions/terraform.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**/*.tf"
+---
+
 # Terraform Instructions
 
 These conventions apply when editing `.tf` files in this project.

--- a/.github/instructions/tsx-style-guide.instructions.md
+++ b/.github/instructions/tsx-style-guide.instructions.md
@@ -1,0 +1,414 @@
+---
+applyTo: "**/*.{ts,tsx}"
+---
+
+# TypeScript/React Style Guide
+
+## File Organization
+
+### File Size Limits
+
+- **Maximum 300 lines per component file**
+- **Maximum 40 lines per component function**
+- When approaching limits, split into:
+  - Smaller sub-components
+  - Custom hooks for logic
+  - Utility functions in separate files
+
+### One Component Per File
+
+- Each `.tsx` file should export ONE primary component
+- Exceptions allowed for:
+  - Tightly coupled sub-components used only within parent
+  - Type definitions specific to that component
+- File name must match component name: `RecipeCard.tsx` exports `RecipeCard`
+
+### File Naming Conventions
+
+- Components: PascalCase (`RecipeDetail.tsx`, `AddRecipeButton.tsx`)
+- Hooks: camelCase with `use` prefix (`useRecipeQuery.ts`, `useAuth.ts`)
+- Utils: camelCase (`formatDate.ts`, `parseIngredients.ts`)
+- Types: camelCase (`recipe.ts`, `mealPlan.ts`)
+
+### Directory Structure
+
+```
+app/
+  (tabs)/              # Tab navigation screens
+  recipe/[id].tsx      # Dynamic route screens
+  add-recipe.tsx       # Modal/standalone screens
+
+components/
+  RecipeCard.tsx       # Reusable UI components
+  GroceryItem.tsx
+
+lib/
+  api.ts               # API client
+  hooks/               # Custom React hooks
+    useRecipes.ts
+    useAuth.ts
+  types.ts             # Shared TypeScript types
+  utils/               # Pure utility functions
+    dateFormatter.ts
+
+test/
+  helpers.ts           # Test utilities
+  setup.ts             # Test configuration
+```
+
+## Component Style
+
+### Function Components Only
+
+- Use function components with hooks
+- No class components
+- Arrow function syntax for component definition:
+
+```tsx
+export const RecipeCard = ({ recipe }: RecipeCardProps) => {
+  // component logic
+};
+```
+
+### Component Structure Order
+
+1. Type definitions (props interface)
+2. Component function declaration
+3. Hooks (useState, useEffect, custom hooks)
+4. Event handlers
+5. Derived/computed values
+6. Early returns (loading, error states)
+7. Main JSX return
+
+```tsx
+interface RecipeCardProps {
+  recipe: Recipe;
+  onPress: (id: string) => void;
+}
+
+export const RecipeCard = ({ recipe, onPress }: RecipeCardProps) => {
+  // 1. Hooks
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { data: image } = useRecipeImage(recipe.id);
+
+  // 2. Event handlers
+  const handlePress = () => {
+    onPress(recipe.id);
+  };
+
+  // 3. Derived values
+  const totalTime = recipe.prep_time + recipe.cook_time;
+
+  // 4. Early returns
+  if (!recipe) return null;
+
+  // 5. Main JSX
+  return <View>{/* component markup */}</View>;
+};
+```
+
+## TypeScript Patterns
+
+### Props Definition
+
+- Use `interface` for component props
+- Suffix with `Props`: `RecipeCardProps`, `HeaderProps`
+- Mark optional props with `?`
+- Avoid `any` - use `unknown` and narrow with type guards
+
+```tsx
+interface RecipeCardProps {
+  recipe: Recipe;
+  onPress: (id: string) => void;
+  showImage?: boolean; // optional
+}
+```
+
+### Type Imports
+
+- Import types explicitly with `type` keyword
+- Group imports: React, third-party, local components, types, utils
+
+```tsx
+import { useState, useEffect } from "react";
+import { View, Text } from "react-native";
+import { useQuery } from "@tanstack/react-query";
+
+import { RecipeCard } from "@/components/RecipeCard";
+import type { Recipe } from "@/lib/types";
+import { formatDate } from "@/lib/utils/dateFormatter";
+```
+
+### Modern Type Syntax
+
+- Use `list[]` not `Array<list>`
+- Use `Record<string, value>` for object maps
+- Use union types: `'pending' | 'success' | 'error'`
+
+```tsx
+// Good
+recipes: Recipe[]
+statusMap: Record<string, boolean>
+status: 'idle' | 'loading' | 'success' | 'error'
+
+// Avoid
+recipes: Array<Recipe>
+statusMap: { [key: string]: boolean }
+```
+
+## React Patterns
+
+### State Management
+
+- Use `useState` for local component state
+- Use `useReducer` for complex state with multiple sub-values
+- Use React Query (`useQuery`, `useMutation`) for server state
+- Never mix server and local state in same `useState`
+
+```tsx
+// Local UI state
+const [isExpanded, setIsExpanded] = useState(false);
+
+// Server state
+const { data: recipes, isLoading } = useQuery({
+  queryKey: ["recipes"],
+  queryFn: fetchRecipes,
+});
+```
+
+### Custom Hooks
+
+- Extract when logic exceeds 20 lines
+- Extract when logic is reused across 2+ components
+- Name with `use` prefix: `useRecipeForm`, `useDebounce`
+- One hook per file in `lib/hooks/`
+
+```tsx
+// lib/hooks/useRecipeForm.ts
+export const useRecipeForm = (initialRecipe?: Recipe) => {
+  const [title, setTitle] = useState(initialRecipe?.title ?? "");
+  const [ingredients, setIngredients] = useState<string[]>(
+    initialRecipe?.ingredients ?? [],
+  );
+
+  const isValid = title.length > 0 && ingredients.length > 0;
+
+  return {
+    title,
+    setTitle,
+    ingredients,
+    setIngredients,
+    isValid,
+  };
+};
+```
+
+### Event Handlers
+
+- Prefix with `handle`: `handlePress`, `handleSubmit`, `handleChange`
+- Extract to named functions (avoid inline arrow functions for complex logic)
+- Pass callbacks down, not state setters
+
+```tsx
+// Good
+const handleSubmit = async () => {
+  await saveRecipe(formData);
+  navigation.goBack();
+};
+
+<Button onPress={handleSubmit} />
+
+// Avoid - too complex inline
+<Button onPress={async () => {
+  await saveRecipe(formData);
+  navigation.goBack();
+}} />
+```
+
+### Conditional Rendering
+
+- Use early returns for loading/error states
+- Use `&&` for simple conditions
+- Use ternary for if/else
+- Extract complex conditionals to computed booleans
+
+```tsx
+// Early return
+if (isLoading) return <LoadingSpinner />;
+if (error) return <ErrorMessage error={error} />;
+
+// Simple condition
+{
+  hasImage && <Image source={{ uri: recipe.image_url }} />;
+}
+
+// If/else
+{
+  isExpanded ? <FullRecipe /> : <RecipeSummary />;
+}
+
+// Complex - extract
+const shouldShowButton = isAuthenticated && !isSubmitting && isValid;
+{
+  shouldShowButton && <Button />;
+}
+```
+
+## Code Quality
+
+### Avoid Duplication
+
+- Extract repeated JSX into components
+- Extract repeated logic into hooks or utils
+- No code blocks >10 lines duplicated
+
+### Self-Documenting Code
+
+- Use descriptive variable/function names
+- Avoid comments - code should explain itself
+- Comments only for "why", never "what"
+
+```tsx
+// Bad - comment explains what code does
+// Check if user is admin
+if (user.role === "admin") {
+}
+
+// Good - code explains itself
+const isAdmin = user.role === "admin";
+if (isAdmin) {
+}
+```
+
+### Immutability
+
+- Never mutate props or state directly
+- Use spread operator for updates
+- Use array methods that return new arrays (`.map()`, `.filter()`)
+
+```tsx
+// Good
+setIngredients([...ingredients, newIngredient]);
+setRecipe({ ...recipe, title: newTitle });
+
+// Bad
+ingredients.push(newIngredient); // mutation
+recipe.title = newTitle; // mutation
+```
+
+## Testing Requirements
+
+### What to Test
+
+- **Custom hooks** with conditional logic or enabled guards
+- **Auth/permission logic** in components
+- **Navigation guards** based on user state
+- **Complex computed values** or transformations
+
+### Test Location
+
+- Component tests: `app/__tests__/*.test.tsx`
+- Hook tests: `lib/hooks/__tests__/*.test.ts`
+- Utility tests: `lib/utils/__tests__/*.test.ts`
+
+### Test Utilities
+
+- Use `mobile/test/helpers.ts` query wrapper
+- Use mock user factory from test helpers
+- Mock React Query with controlled state
+
+```tsx
+// lib/hooks/__tests__/useRecipes.test.ts
+import { renderHook, waitFor } from "@testing-library/react";
+import { createQueryWrapper, mockUser } from "@/test/helpers";
+import { useRecipes } from "../useRecipes";
+
+describe("useRecipes", () => {
+  it("should only fetch when user is authenticated", async () => {
+    const user = mockUser({ id: "123" });
+    const { result } = renderHook(() => useRecipes(), {
+      wrapper: createQueryWrapper({ user }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+```
+
+## Performance
+
+### Optimization Patterns
+
+- Use `React.memo()` for expensive components that re-render frequently
+- Use `useMemo()` for expensive computations
+- Use `useCallback()` for event handlers passed to memoized children
+- Don't optimize prematurely - measure first
+
+```tsx
+// Only when profiling shows performance issue
+const sortedRecipes = useMemo(
+  () => recipes.sort((a, b) => a.title.localeCompare(b.title)),
+  [recipes],
+);
+
+const handlePress = useCallback(
+  (id: string) => navigation.navigate("recipe", { id }),
+  [navigation],
+);
+```
+
+### Lazy Loading
+
+- Use `React.lazy()` for route-level code splitting
+- Use `Suspense` for loading states
+
+## Expo/React Native Specific
+
+### Platform-Specific Code
+
+- Use `Platform.select()` for small differences
+- Use `.ios.tsx` / `.android.tsx` for large differences
+
+```tsx
+import { Platform } from "react-native";
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: Platform.select({
+      ios: 20,
+      android: 0,
+    }),
+  },
+});
+```
+
+### Navigation
+
+- Use Expo Router file-based routing
+- Keep navigation logic in screen components
+- Pass route params with proper TypeScript types
+
+```tsx
+import { useLocalSearchParams, router } from "expo-router";
+
+export default function RecipeDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const handleEdit = () => {
+    router.push(`/recipe/${id}/edit`);
+  };
+
+  // ...
+}
+```
+
+## When to Split Files
+
+Split when you encounter:
+
+1. **File >300 lines** - extract components, hooks, or utils
+2. **Component function >40 lines** - extract sub-components or hooks
+3. **Reused logic** - extract to custom hook in `lib/hooks/`
+4. **Complex state logic** - extract to reducer or separate hook
+5. **Multiple components** - one component per file rule
+6. **Utility functions** - move to `lib/utils/` if used in 2+ files


### PR DESCRIPTION
## Summary

Organize Copilot instruction files and add proper frontmatter for conditional loading.

## Changes

### Instruction files moved to .github/instructions/
- **Moved** `firestore.instructions.md` and `terraform.instructions.md` from `.github/` to `.github/instructions/`
- **Added** `python-style-guide.instructions.md` and `tsx-style-guide.instructions.md` (previously untracked)

### applyTo frontmatter added
All instruction files now have YAML frontmatter with `applyTo` globs so VS Code only loads them when editing relevant file types:

| File | applyTo |
|------|---------|
| `firestore.instructions.md` | `**/*.py` |
| `python-style-guide.instructions.md` | `**/*.py` |
| `terraform.instructions.md` | `**/*.tf` |
| `tsx-style-guide.instructions.md` | `**/*.{ts,tsx}` |

Without frontmatter, instruction files are attached to **every** request regardless of file type, wasting context tokens.

### copilot-instructions.md fix
- Clarified that `.copilot-tasks.md` is gitignored (local-only, never committed to repo)
