### PR TITLE
refactor: preserve original data in recipe enhancement flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,7 @@ You are collaborating with a human who may make changes between your edits:
 - **Before editing Copilot config** - read `copilot-self-improvement` skill before modifying `copilot-instructions.md`, `*.instructions.md`, skills, or `copilot-references.md`
 - **Before committing** - quick security scan: grep staged files for API keys (`AIzaSy`, `sk-`, `ghp_`), emails (`@gmail.com`, `@outlook.com`), project IDs. If found, read `security` skill before proceeding
 - **Update `.copilot-tasks.md` as you work** - mark tasks complete immediately, don't batch updates
+- **Use existing scripts first** - before writing inline Python or ad-hoc commands, check `scripts/` and skill documentation for existing tools that do what you need (e.g., `recipe_reviewer.py` for Firestore recipe operations)
 - **PowerShell backtick escaping** - NEVER use backticks in `gh pr create --body` or similar CLI args. PowerShell interprets `` ` `` as escape characters, causing Unicode parse errors. Instead: write the body to a temp file, then use `--body-file tmp_pr_body.md`, then delete the file
 
 ## Keeping Documentation Current
@@ -164,10 +165,11 @@ infra/                   # Terraform infrastructure
 See `firestore.instructions.md` for the full recipe document schema. Key points:
 
 - Single database: `meal-planner` for all recipes, meal plans, and grocery lists
-- All fields at top level (no nested objects)
+- All fields at top level (one exception: `original` nested snapshot for enhanced recipes)
 - `created_at` required for queries
 - `instructions` must be `list[str]`, not a single string
-- Enhanced recipes have `enhanced=True` and `enhanced_from` set to the source recipe's document ID
+- Enhanced recipes have `enhanced=True` and original data preserved in `original` nested field
+- Enhancement scripts MUST use `.update()` (merge), NEVER `.set()` (overwrite)
 
 ### Skills (AI Agent Instructions)
 

--- a/scripts/upload_enhanced_recipe.py
+++ b/scripts/upload_enhanced_recipe.py
@@ -1,8 +1,9 @@
 """Upload a previously enhanced recipe from JSON to the meal-planner database.
 
-This script is used to re-upload enhanced recipes that were lost or overwritten.
-It reads from a JSON file and writes to the meal-planner database with proper
-field transformations.
+Delegates to recipe_reviewer.upload_from_file which handles:
+- Snapshotting original data into nested `original` field
+- Merging enhanced data at top level via .update() (never .set())
+- Cleaning up legacy fields (improved, original_id, enhanced_from)
 
 Usage:
     uv run python scripts/upload_enhanced_recipe.py <recipe_id>
@@ -11,12 +12,10 @@ Example:
     uv run python scripts/upload_enhanced_recipe.py cPqagQA0l7SaOPo8cKTk
 """
 
-import json
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 
-from google.cloud import firestore
+from scripts.recipe_reviewer import upload_from_file
 
 
 def main() -> None:
@@ -31,63 +30,7 @@ def main() -> None:
         print(f"❌ File not found: {json_path}")
         sys.exit(1)
 
-    print(f"📖 Reading from: {json_path}")
-
-    with json_path.open(encoding="utf-8") as f:
-        recipe = json.load(f)
-
-    # Transform the data to match Firestore schema
-    # Flatten metadata if present
-    if "metadata" in recipe:
-        metadata = recipe.pop("metadata")
-        if "cuisine" in metadata:
-            recipe["cuisine"] = metadata["cuisine"]
-        if "category" in metadata:
-            recipe["category"] = metadata["category"]
-        if "tags" in metadata:
-            recipe["tags"] = metadata["tags"]
-
-    # Ensure instructions is a list (some JSON files have it as a string)
-    if isinstance(recipe.get("instructions"), str):
-        # Split by double newlines to get paragraphs, filter empty
-        instructions_text = recipe["instructions"]
-        # Keep as single timeline string for now - it's a timeline format
-        recipe["instructions"] = [instructions_text]
-
-    # Add required fields
-    now = datetime.now(tz=UTC)
-    recipe["created_at"] = now
-    recipe["updated_at"] = now
-    recipe["improved"] = True
-    recipe["original_id"] = recipe_id
-
-    # Get original recipe URL if not present
-    if "url" not in recipe or not recipe["url"]:
-        # Fetch from database
-        db = firestore.Client(database="meal-planner")
-        original_doc = db.collection("recipes").document(recipe_id).get()
-        if original_doc.exists:  # type: ignore[union-attr]
-            original_data = original_doc.to_dict()  # type: ignore[union-attr]
-            if original_data is not None:
-                recipe["url"] = original_data.get("url", "")
-                recipe["image_url"] = original_data.get("image_url")
-                if not recipe.get("servings"):
-                    recipe["servings"] = original_data.get("servings")
-                print(f"   Retrieved URL from existing recipe: {recipe['url'][:50]}...")
-
-    # Connect to database
-    db = firestore.Client(database="meal-planner")
-    doc_ref = db.collection("recipes").document(recipe_id)
-
-    # Upload
-    doc_ref.set(recipe)
-
-    print(f"✅ Uploaded enhanced recipe: {recipe_id}")
-    print(f"   Title: {recipe['title']}")
-    print(f"   Ingredients: {len(recipe.get('ingredients', []))} items")
-    print(f"   Changes made: {len(recipe.get('changes_made', []))} items")
-    if recipe.get("tips"):
-        print(f"   Tips: {recipe['tips'][:60]}...")
+    upload_from_file(recipe_id, str(json_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refactors recipe enhancement scripts to preserve original scraped data when enhancing recipes.

### Problem

The `recipe_reviewer.py update` command used `.set()` which **overwrote the entire Firestore document**, destroying the original scraped data. There was no way to view the original recipe after enhancement.

### Solution

Enhanced recipes now store both versions in the **same document**:

- **Top-level fields** = enhanced version (what the app displays)
- **`original` nested field** = snapshot of scraped data (for "view original" toggle)
- Uses `.update()` instead of `.set()` to merge without overwriting

### Changes

**Scripts:**
- `recipe_reviewer.py`: Rewritten `update_recipe` to snapshot original on first enhancement, use `.update()`, clean up legacy fields (`improved`, `original_id`, `enhanced_from`)
- `upload_enhanced_recipe.py`: Simplified to delegate to `recipe_reviewer.upload_from_file`

**Documentation:**
- `firestore.instructions.md`: Updated schema with `original` nested field, documented the nesting exception, added enhancement data flow section
- `recipe-improvement/SKILL.md`: Added "Enhancement Data Safety" section with rules and common mistakes
- `copilot-instructions.md`: Updated Firestore schema description

### Data restoration

Recipe `S74yNqQ0aqV1TghZqHJx` was restored by re-scraping from the ICA URL and applying the new structure (original snapshot + enhanced top-level).

### Testing

- 344 tests pass
- ruff clean
- ty clean
