### PR TITLE
docs: fix --reviewer copilot in PR workflow skill

### DIFF
--- a/.github/skills/pr-review-workflow/SKILL.md
+++ b/.github/skills/pr-review-workflow/SKILL.md
@@ -22,13 +22,12 @@ This skill activates when:
 
 After every `git push` to a PR branch, do ALL of the following **in order**:
 
-### Step 1: Request Copilot review
+### Step 1: Copilot review (automated)
 
-```bash
-gh pr edit <PR> --add-reviewer copilot
-```
+Copilot review is triggered automatically by the `copilot-review.yml` GitHub Actions workflow
+on PR open and `ready_for_review`. There is no reliable CLI command to request it manually.
 
-This must happen on EVERY push, not just the first. It triggers a fresh review of the new changes.
+See [Section 8](#8-copilot-review-automation) for details.
 
 ### Step 2: Fetch and present review comments
 
@@ -403,20 +402,18 @@ After addressing comments and fixing CI issues:
 
 ## 8. Creating PRs
 
-### Always request Copilot review
+### Copilot review automation
 
-Every PR must request review from `copilot`. However, `--reviewer copilot` at creation time
-fails with "'copilot' not found" and **aborts the entire PR creation**. Use two steps:
+Copilot review is requested automatically via GitHub Actions (`.github/workflows/copilot-review.yml`).
+There is **no reliable CLI command** to request Copilot review:
 
-```powershell
-# Step 1: Create PR without --reviewer
-gh pr create --title "..." --body-file tmp_pr_body.md
+- `gh pr create --reviewer copilot` → fails with "'copilot' not found", aborts PR creation
+- `gh pr edit <PR> --add-reviewer copilot` → unreliable, sometimes works but not guaranteed
 
-# Step 2: Add Copilot reviewer after creation
-gh pr edit <PR_NUMBER> --add-reviewer copilot
-```
+The workflow uses the [gh-copilot-review](https://github.com/ChrisCarini/gh-copilot-review) extension
+and triggers on `opened`, `ready_for_review`, and `reopened` events.
 
-> ⚠️ **Never** use `gh pr create --reviewer copilot` — it aborts PR creation entirely.
+> **Requires** a fine-grained PAT secret (`GH_TOKEN_COPILOT_REVIEW`) with `Pull requests: Read and write` permission.
 
 ### Multi-line bodies (PowerShell)
 
@@ -430,8 +427,6 @@ NEVER pass backtick-containing text via `--body` in PowerShell — backticks are
 gh pr create --title "feat: ..." --body-file tmp_pr_body.md
 # 3. Delete temp file
 Remove-Item tmp_pr_body.md
-# 4. Add Copilot reviewer
-gh pr edit <PR_NUMBER> --add-reviewer copilot
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fix PR workflow skill section 8 to document that `gh pr create --reviewer copilot` fails with "'copilot' not found" and aborts PR creation entirely.

## Changes

- Removed `--reviewer copilot` from `gh pr create` examples
- Documented the two-step approach: create PR first, then `gh pr edit <PR> --add-reviewer copilot`
- Added warning callout to prevent using the broken flag
- Updated the PowerShell multi-line body example to include the reviewer step

## Context

Discovered during PR #146 creation — `--reviewer copilot` at `gh pr create` time fails and aborts the entire command. The workaround (create then edit) was already in the skill as an alternative but not as the primary approach.
