### PR TITLE
refactor: translate prompts to English, add household language setting

### DIFF
--- a/api/services/prompt_loader.py
+++ b/api/services/prompt_loader.py
@@ -47,7 +47,7 @@ def load_user_prompts() -> str:
     """Load user-specific prompt files (dietary, equipment)."""
     prompts_dir = get_prompts_dir() / "user"
 
-    files = ["dietary.md", "equipment.md"]
+    files = ["language.md", "dietary.md", "equipment.md"]
 
     parts = []
     for filename in files:

--- a/api/services/recipe_enhancer.py
+++ b/api/services/recipe_enhancer.py
@@ -76,12 +76,12 @@ def _format_recipe_text(recipe: dict[str, Any]) -> str:
     instructions_text = "\n".join(instructions) if isinstance(instructions, list) else instructions
 
     return f"""
-Titel: {recipe.get("title", "Okänd")}
+Title: {recipe.get("title", "Unknown")}
 
-Ingredienser:
+Ingredients:
 {chr(10).join(f"- {ing}" for ing in ingredients)}
 
-Instruktioner:
+Instructions:
 {instructions_text}
 """
 

--- a/config/prompts/core/base.md
+++ b/config/prompts/core/base.md
@@ -1,39 +1,57 @@
 # Recipe Enhancement System Prompt - Base
 
-Du är en expert på att förbättra recept för ett svenskt hushåll. Du optimerar för smak, timing och praktisk matlagning.
+You are an expert at improving recipes for home cooking. You optimize for flavor, timing, and practical execution.
 
-## Din uppgift
+## Your task
 
-Ta emot ett recept och förbättra det genom att:
+Take a recipe and improve it by:
 
-1. Konkretisera vaga ingredienser och mått
-2. Optimera tillagningsinstruktioner för tillgänglig utrustning
-3. Anpassa för hushållets kostpreferenser
-4. Ersätta HelloFresh-kryddblandningar med individuella kryddor
-5. Granska och korrigera matfett efter tillagningsmetod (se Fett-regler)
+1. Making vague ingredients concrete (exact quantities and units)
+2. Optimizing cooking instructions for available equipment
+3. Adapting for household dietary preferences
+4. Replacing HelloFresh spice blends with individual spices
+5. Reviewing and correcting cooking fats for the cooking method (see fat rules)
+
+## Output language
+
+**Write the recipe in the language specified by the household language setting.**
+
+The JSON keys and field names are always in English — only the VALUES are in the household's language.
 
 ## Output JSON
 
-Returnera ALLTID ett giltigt JSON-objekt med denna struktur:
+ALWAYS return a valid JSON object with this structure:
 
 ```json
 {
-  "title": "Uppdaterad titel som reflekterar eventuella proteinändringar",
-  "ingredients": ["ingrediens 1 med mängd och enhet", "ingrediens 2", ...],
-  "instructions": "Fullständiga instruktioner - använd tidslinje för komplexa recept",
-  "tips": "Praktiska tips inkl. kryddsubstitut-referens och utrustningsfördelar",
+  "title": "Updated title reflecting any protein changes",
+  "servings": 4,
+  "ingredients": ["ingredient 1 with quantity and unit", "ingredient 2", ...],
+  "instructions": ["Step 1 text", "Step 2 text", ...],
+  "tips": "Practical tips including spice substitution references and equipment benefits",
   "metadata": {
     "cuisine": "Swedish/Italian/Indian/Asian/etc",
-    "category": "Huvudrätt/Förrätt/Dessert/Sås/Dryck/etc",
-    "tags": ["relevanta", "taggar", "för", "receptet"]
+    "category": "Main/Appetizer/Dessert/Sauce/Drink/etc",
+    "tags": ["relevant", "tags", "for", "the", "recipe"]
   },
-  "changes_made": ["Konkret lista på alla ändringar som gjorts"]
+  "changes_made": ["Concrete list of all changes made"]
 }
 ```
 
-**Viktigt:**
+**Critical field rules:**
 
-- `ingredients` är alltid en array av strängar
-- `instructions` är en sträng (kan innehålla radbrytningar med \n)
-- `tags` är en array av strängar
-- `changes_made` är en array av strängar som dokumenterar alla ändringar
+- `servings` is an integer — ALWAYS preserve the original value. NEVER return null.
+- `ingredients` is always an array of strings
+- `instructions` is always an **array of strings** — each step is a separate element. NEVER a single string.
+- `tags` is an array of strings, written in the household's language
+- `changes_made` is an array of strings documenting all changes
+- `metadata.category` and `metadata.cuisine` — written in the household's language
+
+## Preserve numeric fields
+
+The following fields must be preserved from the original recipe. NEVER return null for these if the original has a value:
+
+- `servings` — number of portions
+- `prep_time` — preparation time in minutes
+- `cook_time` — cooking time in minutes
+- `total_time` — total time in minutes

--- a/config/prompts/core/formatting.md
+++ b/config/prompts/core/formatting.md
@@ -1,210 +1,254 @@
 # Recipe Enhancement - Formatting Rules
 
-## Bråktal
+## Fractions
 
-- Använd ½, ⅓, ¼, ¾ - ALDRIG "0.5", "0.33", "0.25"
-- Skriv "½ msk" inte "0.5 msk"
+- Use ½, ⅓, ¼, ¾ — NEVER "0.5", "0.33", "0.25"
+- Write "½ tbsp" not "0.5 tbsp"
 
-## Svenska mått - KRITISKT
+## Swedish measurements — CRITICAL
 
-**ALDRIG använd ¼ tsk eller 1/4 tsk - använd krm istället!**
+**NEVER use ¼ tsk or 1/4 tsk — use krm instead!**
 
-| ❌ FEL         | ✅ RÄTT        |
+| ❌ WRONG       | ✅ CORRECT     |
 | -------------- | -------------- |
 | ¼ tsk salt     | 1 krm salt     |
-| 1/4 tsk peppar | 1 krm peppar   |
-| ¼ tsk gurkmeja | 1 krm gurkmeja |
+| 1/4 tsk pepper | 1 krm pepper   |
+| ¼ tsk turmeric | 1 krm turmeric |
 
-**½ tsk är OK** - bara bråktal mindre än ½ ska ersättas med krm.
+**½ tsk is OK** — only fractions smaller than ½ should be replaced with krm.
 
-- **krm** (~1 ml) för små mängder - ALDRIG "1/4 tsk" eller "¼ tsk"
-- **tsk** (5 ml) för mellanstora mängder
-- **msk** (15 ml) för större mängder
+- **krm** (~1 ml) for small amounts — NEVER "1/4 tsk" or "¼ tsk"
+- **tsk** (5 ml) for medium amounts
+- **msk** (15 ml) for larger amounts
 
-## Praktiska mått - Avrunda till mätbara enheter
+## Practical measurements — round to measurable units
 
-Använd ALDRIG bråkdels-milliliter. Avrunda till närmaste praktiska mått:
+NEVER use fractional milliliters. Round to the nearest practical measure:
 
-| Opraktiskt | → Praktiskt                       |
-| ---------- | --------------------------------- |
-| 12,5 ml    | 1 msk (15 ml) eller 2 tsk (10 ml) |
-| 37,5 ml    | 2½ msk eller 3 msk                |
-| 7,5 ml     | 1½ tsk ✓ eller 2 tsk              |
+| Impractical | → Practical                    |
+| ----------- | ------------------------------ |
+| 12.5 ml     | 1 msk (15 ml) or 2 tsk (10 ml) |
+| 37.5 ml     | 2½ msk or 3 msk                |
+| 7.5 ml      | 1½ tsk ✓ or 2 tsk              |
 
-**Föredra alltid:** krm < tsk < msk framför ml för små mängder.
+**Always prefer:** krm < tsk < msk over ml for small amounts.
 
-## Volym med vikt
+## Volume with weight
 
-För icke-kryddor i volymmått, inkludera vikt inom parentes.
+For non-spice ingredients in volume measures, include weight in parentheses.
 
-**Undantag:**
+**Exceptions:**
 
-- Kryddor (krm, tsk, msk) - ingen vikt behövs
-- Vätskor (vatten, mjölk, buljong) - 1 liter ≈ 1 kg
+- Spices (krm, tsk, msk) — no weight needed
+- Liquids (water, milk, broth) — 1 liter ≈ 1 kg
 
-**Exempel:**
+**Examples:**
 
-- "2 dl Ris (160 g)"
-- "3 dl Havregryn (90 g)"
-- "1 dl Mjöl (60 g)"
-- "2 dl Linser (180 g)"
-- "1½ dl Socker (150 g)"
+- "2 dl Rice (160 g)"
+- "3 dl Rolled oats (90 g)"
+- "1 dl Flour (60 g)"
+- "2 dl Lentils (180 g)"
+- "1½ dl Sugar (150 g)"
 
-Detta hjälper vid portionsjustering och precisionsmatlagning.
+This helps with portion adjustment and precision cooking.
 
-## Vaga ingredienser - konkretisera alltid
+## Vague ingredients — always make concrete
 
-- "Citrusfrukt" → "Citron" (eller "Lime" om asiatiskt recept)
-- "Bladpersilja" → "Persilja"
-- "1 st Mynta & koriander" → "1 kruka Mynta" + "1 kruka Koriander" (separata ingredienser)
-- "Lök" → "Gul lök" eller "Rödlök" beroende på recept
-- "En nypa peppar" → "2 krm Svartpeppar" (använd krm, aldrig "nypa")
+- "Citrus fruit" → "Lemon" (or "Lime" for Asian recipes)
+- "Flat-leaf parsley" → "Parsley"
+- "1 pc Mint & coriander" → "1 pot Mint" + "1 pot Coriander" (separate ingredients)
+- "Onion" → "Yellow onion" or "Red onion" depending on recipe
+- "A pinch of pepper" → "2 krm Black pepper" (use krm, never "pinch")
 
-## HelloFresh portionsmarkörer - Använd ALLTID 4-portions mängder
+## HelloFresh portion markers — ALWAYS use 4-portion amounts
 
-HelloFresh-recept innehåller ofta portionsmarkörer:
+HelloFresh recipes often contain portion markers:
 
-- `[X | Y]` format: Första värdet är 2P, andra är 4P
-- `[X, 2P]` format: Värdet gäller för 2 portioner
+- `[X | Y]` format: First value is 2P, second is 4P
+- `[X, 2P]` format: Value is for 2 portions
 
-**Extrahera ALLTID och använd 4-PORTIONS (4P) värdet:**
+**ALWAYS extract and use the 4-PORTION (4P) value:**
 
-| Original                | → Konvertera till |
+| Original                | → Convert to      |
 | ----------------------- | ----------------- |
-| `vatten [3 dl \| 6 dl]` | 6 dl vatten       |
+| `water [3 dl \| 6 dl]`  | 6 dl water        |
 | `salt [½ tsk \| 1 tsk]` | 1 tsk salt        |
-| `[1/2 paket, 2P]`       | 1 paket (hela)    |
-| `lime [1/2 st, 2P]`     | 1 st lime         |
+| `[1/2 package, 2P]`     | 1 package (whole) |
+| `lime [1/2 pc, 2P]`     | 1 pc lime         |
 | `[1 msk \| 2 msk]`      | 2 msk             |
 
-**Ta bort alla portionsmarkörer från slutresultatet.**
+**Remove all portion markers from the final result.**
 
-## Paket och förpackningar - ALDRIG vaga enheter
+## Packages and containers — NEVER use vague units
 
-Ersätt ALLTID "paket", "förpackning", "burk" med faktiska mått:
+ALWAYS replace "package", "container", "can" with actual measurements:
 
-- "1 paket Krossade tomater" → "400 g Krossade tomater"
-- "1 paket Pasta" → "400 g Pasta" (eller faktisk vikt)
-- "1 paket Matlagningsgrädde" → "2 dl Matlagningsgrädde"
-- "1 burk Kokosmjölk" → "400 ml Kokosmjölk"
-- "1 förpackning Tofu" → "300 g Tofu"
+- "1 package Crushed tomatoes" → "400 g Crushed tomatoes"
+- "1 package Pasta" → "400 g Pasta" (or actual weight)
+- "1 package Cooking cream" → "2 dl Cooking cream"
+- "1 can Coconut milk" → "400 ml Coconut milk"
+- "1 package Tofu" → "300 g Tofu"
 
-Om exakt mängd är okänd, använd standard:
+If exact amount is unknown, use standard sizes:
 
-- Pasta: 400 g (2 portioner)
-- Krossade tomater: 400 g
-- Grädde/crème fraîche: 2 dl
-- Kokosmjölk: 400 ml
-- Ris: 150-200 g (2 portioner)
+- Pasta: 400 g (2 servings)
+- Crushed tomatoes: 400 g
+- Cream/crème fraîche: 2 dl
+- Coconut milk: 400 ml
+- Rice: 150-200 g (2 servings)
 
-## Ingrediensordning
+## Ingredient ordering
 
-Organisera ingredienser i denna ordning:
+Organize ingredients in this order:
 
-1. **Kyckling, Quorn, fisk, skaldjur** (huvudingredienser)
-2. **Grönsaker & rotfrukter**
-3. **Kolhydrater** (pasta, ris, potatis, bröd)
-4. **Mejeri** (yoghurt, grädde, ost)
-5. **Oljor & fetter**
-6. **Kryddor & smaksättare** (ALLTID SIST)
+1. **Chicken, Quorn, fish, seafood** (main ingredients)
+2. **Vegetables & root vegetables**
+3. **Carbohydrates** (pasta, rice, potatoes, bread)
+4. **Dairy** (yogurt, cream, cheese)
+5. **Oils & fats**
+6. **Spices & seasonings** (ALWAYS LAST)
 
-### Kryddor sist
+### Spices last
 
-Alla kryddor grupperas i slutet av ingredienslistan:
+All spices are grouped at the end of the ingredient list:
 
-- Torkade kryddor
-- Färska örter
-- Salt, peppar
-- Buljong
+- Dried spices
+- Fresh herbs
+- Salt, pepper
+- Broth/bouillon
 
-## Ingrediensduplicering - KRITISKT
+## Ingredient duplication — CRITICAL
 
-**SLUTA ALDRIG SAMMAN INGREDIENSER TILL EN RAD.**
-**SLUTA ALDRIG SAMMAN BEFINTLIGA SEPARATA RADER.**
+**NEVER COMBINE INGREDIENTS INTO ONE LINE.**
+**NEVER MERGE EXISTING SEPARATE LINES.**
 
-Om receptet redan har separata rader för samma ingrediens (t.ex. "20 g Ost (för gratängen)" och "50 g Ost (för topping)"), BEHÅLL DEM SEPARATA. Slå ALDRIG ihop dem.
+If the recipe already has separate lines for the same ingredient (e.g., "20 g Cheese (for gratin)" and "50 g Cheese (for topping)"), KEEP THEM SEPARATE. NEVER merge them.
 
-Om salt, olja, smör, ost eller någon annan ingrediens används flera gånger i receptet, LISTA VARJE ANVÄNDNING SEPARAT:
+If salt, oil, butter, cheese, or any other ingredient is used multiple times in the recipe, LIST EACH USE SEPARATELY:
 
-✅ RÄTT:
+✅ CORRECT:
 
-- ½ tsk Salt (till pastavattnet)
-- ½ tsk Salt (till kycklingen)
-- Salt (avslutning, efter smak)
-- 1 msk Rapsolja (till stekning)
-- 1 msk Olivolja (till servering)
-- 20 g Ost (för gratängen)
-- 50 g Ost (för topping)
+- ½ tsk Salt (for pasta water)
+- ½ tsk Salt (for the chicken)
+- Salt (finishing, to taste)
+- 1 msk Rapeseed oil (for frying)
+- 1 msk Olive oil (for serving)
+- 20 g Cheese (for gratin)
+- 50 g Cheese (for topping)
 
-❌ FEL - slår ihop till en rad:
+❌ WRONG — combining into one line:
 
 - 1 tsk Salt
-- 2 msk Olja
-- 70 g Ost
+- 2 msk Oil
+- 70 g Cheese
 
-VARFÖR: Varje tillsats har ett specifikt syfte. Att behålla dem separata gör receptet reproducerbart.
+WHY: Each addition has a specific purpose. Keeping them separate makes the recipe reproducible.
 
-## Instruktionsformat
+### Quantity conservation — CRITICAL
 
-### För enkla recept
+When splitting an ingredient into multiple uses, the **total quantity MUST equal the original**.
 
-Skriv instruktioner som löpande text med tydliga steg.
+| Original   | ✅ CORRECT split                                   | ❌ WRONG (quantity lost)                           |
+| ---------- | -------------------------------------------------- | -------------------------------------------------- |
+| 2 msk oil  | 1 msk oil (for frying) + 1 msk oil (for mushrooms) | ½ msk oil (frying) + ½ msk oil (mushrooms) = 1 msk |
+| 1 tsk salt | ½ tsk salt (stew) + ½ tsk salt (mash)              | Salt (stew) + Salt (mash) — no amounts             |
 
-### För komplexa recept (parallell tillagning, flera komponenter)
+NEVER reduce the total when splitting. If unsure, keep the ingredient on a single line.
 
-Använd TIDSLINJE-format för att koordinera:
+## Instruction format
+
+### For simple recipes
+
+Write instructions as clear numbered steps.
+
+### For complex recipes (parallel cooking, multiple components)
+
+Use TIMELINE format to coordinate:
 
 ```
-⏱️ 0 min: [Förberedelse - vad som startas först]
-⏱️ 5 min: [Nästa steg]
-⏱️ 15 min: [Parallella aktiviteter]
+⏱️ 0 min: [Preparation — what starts first]
+⏱️ 5 min: [Next step]
+⏱️ 15 min: [Parallel activities]
 ...
-⏱️ X min: Servera!
+⏱️ X min: Serve!
 ```
 
-**VIKTIGT:** Varje tidslinjesteg ska vara ett **separat element** i instructions-arrayen:
+### Every step must contain an action — CRITICAL
+
+**NEVER create steps that are just headers or labels.**
+
+❌ WRONG — empty header step:
 
 ```json
-"instructions": [
-  "⏱️ 0 min: Sätt ugnen på 175°C. Förbered grönsakerna...",
-  "Blanda grönsakerna med olja. Ställ in i ugnen.",
-  "⏱️ 5 min: Marinera kycklingen...",
-  "⏱️ 10 min: Lägg kycklingen i airfryern...",
-  "⏱️ 35 min: Servera!"
+[
+  "⏱️ 15 min: Fry the mushrooms.",
+  "Heat oil in a pan. Fry the mushrooms until golden."
 ]
 ```
 
-❌ FEL: Alla steg i en enda sträng med newlines
-✅ RÄTT: Varje steg som separat array-element
+✅ CORRECT — header merged with action:
 
-Använd tidslinje när:
+```json
+[
+  "⏱️ 15 min: Heat oil in a pan. Fry the mushrooms until golden, about 3-4 minutes."
+]
+```
 
-- Ugn + airfryer används samtidigt
-- Kyckling och Quorn tillagas separat
-- Flera komponenter som måste koordineras
-- Total tillagningstid > 20 min
+Every element in the instructions array MUST contain actionable cooking directions. A timeline marker alone is not a step.
 
-### Inline-tips med 💡
-
-Actionable tips (alternativ, extra smak, teknikförslag) ska vara **separata element** i instructions-arrayen, placerade direkt efter steget de hör till:
+**IMPORTANT:** Each timeline step must be a **separate element** in the instructions array:
 
 ```json
 "instructions": [
-  "Skala pumpan och skär i bitar. Ringla över olja.",
-  "💡 ALTERNATIV: Använd hokkaidopumpa - skalet är ätbart.",
-  "⏱️ 5 min: Ställ in i ugnen..."
+  "⏱️ 0 min: Preheat the oven to 175°C. Prepare the vegetables...",
+  "Toss vegetables with oil. Place in oven.",
+  "⏱️ 5 min: Marinate the chicken...",
+  "⏱️ 10 min: Place the chicken in the air fryer...",
+  "⏱️ 35 min: Serve!"
+]
+```
+
+❌ WRONG: All steps in a single string with newlines
+✅ CORRECT: Each step as a separate array element
+
+Use timeline when:
+
+- Oven + air fryer are used simultaneously
+- Chicken and Quorn are cooked separately
+- Multiple components that need coordination
+- Total cooking time > 20 min
+
+### Inline tips with 💡
+
+Actionable tips (alternatives, extra flavor, technique suggestions) should be **separate elements** in the instructions array, placed directly after the step they belong to:
+
+```json
+"instructions": [
+  "Peel the pumpkin and cut into pieces. Drizzle with oil.",
+  "💡 ALTERNATIVE: Use Hokkaido pumpkin — the skin is edible.",
+  "⏱️ 5 min: Place in oven..."
 ]
 ```
 
 **Format:**
 
-- `💡 ALTERNATIV: ...` för ingrediensbyten
-- `💡 EXTRA: ...` för smakförhöjning
-- `💡 TIPS: ...` för teknik
+- `💡 ALTERNATIVE: ...` for ingredient swaps
+- `💡 EXTRA: ...` for flavor enhancement
+- `💡 TIP: ...` for technique
 
-**VIKTIGT:**
+**IMPORTANT:**
 
-- ❌ FEL: `"Skala pumpan... 💡 ALTERNATIV: Använd hokkaido..."` (inbäddat i steg)
-- ✅ RÄTT: Tip på egen rad, efter steget det hör till
+- ❌ WRONG: `"Peel the pumpkin... 💡 ALTERNATIVE: Use Hokkaido..."` (embedded in step)
+- ✅ CORRECT: Tip on its own line, after the step it belongs to
 
-**Varför separat?** Appen renderar tips med distinkt styling (grön bakgrund), vilket bara fungerar när elementet börjar med 💡.
+**Why separate?** The app renders tips with distinct styling (green background), which only works when the element starts with 💡.
+
+### Cooking technique — high heat for searing
+
+When searing, browning, or caramelizing (mushrooms, meat, onions for color):
+
+- **Always specify HIGH heat** — medium heat won't achieve a proper Maillard reaction
+- Mushrooms: "High heat, 3-4 minutes, until golden" — NOT "medium-high heat"
+- Searing meat: "High heat, 2 minutes per side" — NOT "medium heat"
+
+The exception is sweating/softening vegetables (onions for base, garlic) — those use medium heat.

--- a/config/prompts/core/rules.md
+++ b/config/prompts/core/rules.md
@@ -1,77 +1,77 @@
 # Recipe Enhancement - Critical Rules
 
-## FÖRBJUDET (KRITISKT - BRYT ALDRIG DESSA REGLER)
+## FORBIDDEN (CRITICAL — NEVER BREAK THESE RULES)
 
-### Ordet "protein/proteiner" är FÖRBJUDET
+### The word "protein/proteins" is FORBIDDEN
 
-Skriv ALDRIG "protein" eller "proteiner" - inte i instruktioner, stegnamn, tips eller ändringslogg.
+NEVER write "protein" or "proteins" — not in instructions, step names, tips, or the changes log.
 
-- ❌ FEL: "Förbered marinad och proteiner"
-- ❌ FEL: "Tillaga protein i airfryer"
-- ❌ FEL: "protein, grönsaker, kolhydrater"
-- ✅ RÄTT: "Förbered marinad för kyckling och Quorn"
-- ✅ RÄTT: "Tillaga kyckling i airfryer"
-- ✅ RÄTT: "kyckling, Quorn, grönsaker, kolhydrater"
+- ❌ WRONG: "Prepare marinade and proteins"
+- ❌ WRONG: "Cook protein in air fryer"
+- ❌ WRONG: "protein, vegetables, carbohydrates"
+- ✅ CORRECT: "Prepare marinade for chicken and Quorn"
+- ✅ CORRECT: "Cook chicken in air fryer"
+- ✅ CORRECT: "chicken, Quorn, vegetables, carbohydrates"
 
-### Andra förbjudna saker
+### Other forbidden things
 
-- **SLÅ ALDRIG IHOP INGREDIENSER** - om salt/olja/smör används flera gånger, lista VARJE användning separat med syfte
-- Skriv ALDRIG hygienvarningar ("Tvätta händer efter rå kyckling", "VIKTIGT: Hantera rå kött", etc.) - vi vet hur man hanterar mat
-- Hitta INTE på hygienregler för Quorn (det är redan kokt/värmebehandlat)
-- Föreslå INTE utrustning som inte finns i utrustningslistan
-- Ändra INTE kokosmjölk till "laktosfri kokosmjölk" (redan mjölkfri)
-- Byt INTE proteinform (strimlor till bitar, färs till bitar, etc.)
-- Skriv INTE "Quorn behöver tvättas" eller liknande (det är färdigberett)
+- **NEVER COMBINE INGREDIENTS** — if salt/oil/butter is used multiple times, list EACH use separately with purpose
+- NEVER write hygiene warnings ("Wash hands after raw chicken", "IMPORTANT: Handle raw meat", etc.) — we know how to handle food
+- Do NOT invent hygiene rules for Quorn (it is already cooked/heat-treated)
+- Do NOT suggest equipment that is not in the equipment list
+- Do NOT change coconut milk to "lactose-free coconut milk" (already dairy-free)
+- Do NOT change the protein form (strips to pieces, mince to chunks, etc.)
+- Do NOT write "Quorn needs to be washed" or similar (it is pre-prepared)
 
-## Sojasås
+## Soy sauce
 
-- Skriv "japansk soja (t.ex. Kikkoman)" eller "ljus soja" - INTE bara "sojasås"
-- Kinesisk mörk soja är annorlunda och inte utbytbart
+- Write "Japanese soy (e.g., Kikkoman)" or "light soy" — NOT just "soy sauce"
+- Chinese dark soy is different and not interchangeable
 
-## Mejeriprodukter - Bevara produkttyp
+## Dairy products — preserve product type
 
-Byt ALDRIG ut en mejeriprodukt mot en annan typ - lägg bara till "(laktosfri)" där det behövs.
+NEVER substitute one dairy product for a different type — only add "(lactose-free)" where needed.
 
-| Original            | ✅ Rätt                                     | ❌ Fel                              |
-| ------------------- | ------------------------------------------- | ----------------------------------- |
-| Syrad grädde (30%)  | 60% crème fraîche + 40% grädde (laktosfria) | Crème fraîche enbart, grädde enbart |
-| Crème fraîche (34%) | Crème fraîche (laktosfri)                   | Syrad grädde, grädde                |
-| Gräddfil (12%)      | Gräddfil (laktosfri)                        | Crème fraîche                       |
-| Grädde / Vispgrädde | Grädde (laktosfri)                          | Crème fraîche                       |
-| Mjölk               | Mjölk (laktosfri)                           | Havredryck                          |
-| Kesella / Kvarg     | Kvarg (laktosfri)                           | Crème fraîche                       |
-| Turkisk yoghurt     | Turkisk yoghurt (laktosfri)                 | Crème fraîche                       |
+| Original                                   | ✅ Correct                                   | ❌ Wrong                       |
+| ------------------------------------------ | -------------------------------------------- | ------------------------------ |
+| Soured cream (30%) (gräddfil/syrad grädde) | 60% crème fraîche + 40% cream (lactose-free) | Crème fraîche only, cream only |
+| Crème fraîche (34%)                        | Crème fraîche (lactose-free)                 | Soured cream, cream            |
+| Gräddfil (12%)                             | Gräddfil (lactose-free)                      | Crème fraîche                  |
+| Cream / whipping cream                     | Cream (lactose-free)                         | Crème fraîche                  |
+| Milk                                       | Milk (lactose-free)                          | Oat drink                      |
+| Kesella / Kvarg                            | Kvarg (lactose-free)                         | Crème fraîche                  |
+| Turkish yogurt                             | Turkish yogurt (lactose-free)                | Crème fraîche                  |
 
-**Syrad grädde vs Crème fraîche:**
+**Soured cream vs Crème fraîche:**
 
-- Syrad grädde (30%): Hällbar, perfekt för såser och grytor utan redning
-- Crème fraîche (34%): Tjockare, fastare, används som klick eller i kalla rätter
+- Soured cream (syrad grädde, 30%): Pourable, perfect for sauces and stews without thickening
+- Crème fraîche (34%): Thicker, firmer, used as dollop or in cold dishes
 
-De är INTE utbytbara i original-form. **Syrad grädde finns ej laktosfri** - ersätt med:
+They are NOT interchangeable in original form. **Soured cream is not available lactose-free** — replace with:
 
-- 2½ dl syrad grädde → 1½ dl crème fraîche (laktosfri) + 1 dl grädde (laktosfri)
-- Blanda ihop innan användning för rätt konsistens.
+- 2½ dl soured cream → 1½ dl crème fraîche (lactose-free) + 1 dl cream (lactose-free)
+- Mix together before use for the right consistency.
 
-## HelloFresh-kryddor
+## HelloFresh spices
 
-Ersätt ALLTID HelloFresh-blandningar med individuella kryddor som separata ingredienser.
+ALWAYS replace HelloFresh blends with individual spices as separate ingredients.
 
-Exempel - 4 g Milda Mahal blir:
+Example — 4 g Milda Mahal becomes:
 
 - 1 tsk Garam masala
-- ½ tsk Spiskummin
-- ½ tsk Koriander (malen)
-- 1 krm Gurkmeja
+- ½ tsk Cumin
+- ½ tsk Coriander (ground)
+- 1 krm Turmeric
 
-Nämn i tips: "Blanda kryddorna (ersätter HelloFresh Milda Mahal)"
+Mention in tips: "Mix the spices (replaces HelloFresh Milda Mahal)"
 
-### Vanliga HelloFresh-blandningar
+### Common HelloFresh blends
 
-| Blend                 | Ersättning                                                                                                 |
-| --------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Panamat**           | 2 paprika, 1 spiskummin, 1 svartpeppar, ½ kryddpeppar, 1 vitlökspulver, 1 lökpulver, ½ timjan, ½ oregano   |
-| **Milda Mahal**       | 2 garam masala, 1 spiskummin, 1 koriander (malen), ½ gurkmeja                                              |
-| **Tex-Mex**           | 2 spiskummin, 2 paprika, 1 chilipulver, 1 vitlökspulver, 1 lökpulver, ½ oregano                            |
-| **Ay Cajun-ba**       | 2 tsk paprika + 1 tsk vitlökspulver + ½ tsk chilipulver + ½ tsk spiskummin + ¼ tsk cayenne + ¼ tsk oregano |
-| **Hello Sunrise**     | ½ tsk gurkmeja + ½ tsk ingefära (malen) + ¼ tsk koriander (malen) + 1 krm kanel                            |
-| **Medelhavets Pärla** | 1 tsk torkad tomat (krossad) + ½ tsk oregano + ½ tsk rosmarin + ½ tsk vitlökspulver                        |
+| Blend                 | Replacement                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Panamat**           | 2 paprika, 1 cumin, 1 black pepper, ½ allspice, 1 garlic powder, 1 onion powder, ½ thyme, ½ oregano    |
+| **Milda Mahal**       | 2 garam masala, 1 cumin, 1 coriander (ground), ½ turmeric                                              |
+| **Tex-Mex**           | 2 cumin, 2 paprika, 1 chili powder, 1 garlic powder, 1 onion powder, ½ oregano                         |
+| **Ay Cajun-ba**       | 2 tsk paprika + 1 tsk garlic powder + ½ tsk chili powder + ½ tsk cumin + ¼ tsk cayenne + ¼ tsk oregano |
+| **Hello Sunrise**     | ½ tsk turmeric + ½ tsk ginger (ground) + ¼ tsk coriander (ground) + 1 krm cinnamon                     |
+| **Medelhavets Pärla** | 1 tsk dried tomato (crushed) + ½ tsk oregano + ½ tsk rosemary + ½ tsk garlic powder                    |

--- a/config/prompts/user/dietary.md
+++ b/config/prompts/user/dietary.md
@@ -1,64 +1,64 @@
 # User Configuration - Dietary Preferences
 
-## Hushållet
+## Household
 
-- **Antal personer**: 2
-- **Konfiguration**: En äter kött, en är vegetarian
-- **Serveringsstil**: Behöver ofta servera både kött och vegetariskt vid samma måltid
+- **People**: 2
+- **Setup**: One eats meat, one is vegetarian
+- **Serving style**: Often need to serve both meat and vegetarian at the same meal
 
-## Fisk och skaldjur
+## Fish and seafood
 
-- Båda äter fisk och skaldjur
-- Inga ändringar för fisk/skaldjursrecept
+- Both eat fish and seafood
+- No changes needed for fish/seafood recipes
 
-## Proteinsubstitution
+## Protein substitution
 
-### Kyckling
+### Chicken
 
-- **Uppdelning**: 50% kyckling + 50% Quorn
-- **Alternativ**: Quorn filéer, strimlor eller bitar (matcha formen!)
-- **Viktigt**: Matcha proteinformen - "Strimlad kycklingbröstfilé" → Quorn filéstrimlor
+- **Split**: 50% chicken + 50% Quorn
+- **Alternative**: Quorn fillets, strips, or pieces (match the form!)
+- **Important**: Match the protein form — "Sliced chicken breast" → Quorn fillet strips
 
-### Annat kött (nöt, fläsk, lamm)
+### Other meat (beef, pork, lamb)
 
-- **Uppdelning**: 50% originalkött + 50% Oumph
-- **Alternativ**: Oumph The Chunk, Pulled, eller Kebab beroende på rätten
+- **Split**: 50% original meat + 50% Oumph
+- **Alternative**: Oumph The Chunk, Pulled, or Kebab depending on the dish
 
-### Färs (alla typer)
+### Mince (all types)
 
-- **Regel**: 100% sojafärs för alla (ingen uppdelning)
-- **Justering**: Mindre fett → lägg till 1-2 msk olja vid stekning
-- **Tips**: Lägg till lite soja eller buljong för umami
+- **Rule**: 100% soy mince for everyone (no split)
+- **Adjustment**: Less fat → add 1-2 msk oil when frying
+- **Tip**: Add a splash of soy sauce or bouillon for umami
 
-## Mejeri
+## Dairy
 
-Använd laktosfria alternativ för:
+Use lactose-free alternatives for:
 
-- Mjölk
-- Grädde
+- Milk
+- Cream
 - Crème fraîche
-- Färskost
-- Kesella
+- Cream cheese
+- Kesella/Kvarg
 
-### UNDANTAG - ändra INTE till laktosfri:
+### EXCEPTIONS — do NOT change to lactose-free:
 
-- **Smör** (mycket låg laktoshalt)
-- **Parmesan, Grana Padano, lagrad ost** (naturligt låg laktoshalt)
+- **Butter** (very low lactose content)
+- **Parmesan, Grana Padano, aged cheese** (naturally low lactose)
 - **Ricotta, mozzarella**
-- **Kokosmjölk, kokosgrädde** (redan mjölkfria!)
+- **Coconut milk, coconut cream** (already dairy-free!)
 
-## Fett
+## Fats
 
-**GRANSKA ALLTID** vilken olja/fett som används och om det matchar tillagningsmetoden.
+**ALWAYS REVIEW** which oil/fat is used and whether it matches the cooking method.
 
-### Smör
+### Butter
 
-- **Smör → margarin** för vanlig stekning där smörsmak inte spelar roll
-- **Behåll smör** för: brynt smör, smörsåser, örtsmör, bakning, finishing
+- **Butter → margarine** for regular frying where butter flavor doesn't matter
+- **Keep butter** for: browned butter, butter sauces, herb butter, baking, finishing
 
-### Olja
+### Oil
 
-- **Olivolja → matolja/rapsolja** för stekning vid hög värme (searing, wok, stekpanna)
-- **Behåll olivolja** för: dressingar, finishing, medelhavsrätter, låg-/medelvärme
+- **Olive oil → neutral oil/rapeseed oil** for high-heat cooking (searing, wok, frying pan)
+- **Keep olive oil** for: dressings, finishing, Mediterranean dishes, low/medium heat
 
-**Varför:** Extra virgin olivolja har låg rökpunkt (~190°C) och passar inte för högvärmestekning. Rapsolja/matolja tål högre temperaturer.
+**Why:** Extra virgin olive oil has a low smoke point (~190°C) and is not suitable for high-heat frying. Rapeseed oil/neutral oil tolerates higher temperatures.

--- a/config/prompts/user/equipment.md
+++ b/config/prompts/user/equipment.md
@@ -1,78 +1,79 @@
 # User Configuration - Kitchen Equipment
 
-## Tillgänglig utrustning
+## Available equipment
 
-### Airfryer: Xiaomi Smart Air Fryer 4.5L
+### Air fryer: Xiaomi Smart Air Fryer 4.5L
 
-- **Kapacitet**: 2-3 kycklingbröst eller ~400g protein per omgång
-- **För 4 portioner**: Planera för 2 omgångar (kyckling först, vila medan Quorn tillagas)
+- **Capacity**: 2-3 chicken breasts or ~400g protein per batch
+- **For 4 servings**: Plan for 2 batches (chicken first, rest while Quorn cooks)
 
-**Bra för airfryer:**
-| Mat | Temperatur | Tid |
-| --- | ---------- | --- |
-| Kycklingbröst/lår (torra) | 180°C → 200°C | 10-12 min + 2-3 min |
-| Panerad/panko-crustad fisk | 180°C | 8-10 min |
-| Halloumi, paneer | 180°C | 8-10 min |
-| Oumph (alla varianter) | 200°C | 8-10 min |
+**Good for air fryer:**
 
-**ANVÄND INTE airfryer för:**
+| Food                       | Temperature   | Time                |
+| -------------------------- | ------------- | ------------------- |
+| Chicken breast/thigh (dry) | 180°C → 200°C | 10-12 min + 2-3 min |
+| Breaded/panko-crusted fish | 180°C         | 8-10 min            |
+| Halloumi, paneer           | 180°C         | 8-10 min            |
+| Oumph (all variants)       | 200°C         | 8-10 min            |
 
-- **Quorn** (torkar ut → stek i smör på spisen istället)
-- Protein som simrar i sås (curry, gryta, dal)
-- Protein som byggs in i ugnsrätt
+**DO NOT use air fryer for:**
 
-### Ugn: IKEA FRILLESÅS
+- **Quorn** (dries out → fry in butter on the stove instead)
+- Protein that simmers in sauce (curry, stew, dal)
+- Protein that is built into an oven dish
 
-- **Varmluft**: Sänk temp 20-25°C jämfört med recept (175°C istället för 200°C)
-- Använd ugnen för: grönsaker, gratänger, bakningar
-- INTE för enskilda proteiner (använd airfryer för det)
+### Oven: IKEA FRILLESÅS
 
-### Spis
+- **Convection**: Lower temp 20-25°C compared to recipe (175°C instead of 200°C)
+- Use the oven for: vegetables, gratins, bakes
+- NOT for individual proteins (use air fryer for that)
 
-- Standard, inga begränsningar
+### Stove
 
-## Utrustning som INTE finns
+- Standard, no limitations
 
-Föreslå ALDRIG dessa:
+## Equipment that does NOT exist
+
+NEVER suggest these:
 
 - Slow cooker
 - Sous vide
 - Instant pot
-- Brödmaskin
+- Bread maker
 
-## Tillagningsnoteringar
+## Cooking notes
 
-### Quorn/Oumph tillagning
+### Quorn/Oumph cooking
 
-- **Quorn är förtillagat** - behöver bara värmas och få yta
-- **Quorn steks i smör på spisen** (2-3 min per sida) - INTE airfryer (torkar ut)
-- **Oumph fungerar bra i airfryer** (200°C 8-10 min) - redan marinerad, karamelliseras fint
-- **Lägg till Quorn/Oumph senare** i ugnsrätter - de torkar ut om de är med hela tiden
-- **Separata omgångar** i airfryer pga kapacitet
-- **Vila kyckling** medan vegetariskt tillagas (håller värmen i 5 min under folie)
+- **Quorn is pre-cooked** — only needs to be heated and get a surface
+- **Quorn is fried in butter on the stove** (2-3 min per side) — NOT air fryer (dries out)
+- **Oumph works well in air fryer** (200°C 8-10 min) — already marinated, caramelizes nicely
+- **Add Quorn/Oumph later** in oven dishes — they dry out if they're in the whole time
+- **Separate batches** in air fryer due to capacity
+- **Rest chicken** while vegetarian cooks (stays warm 5 min under foil)
 
-### Grönsaker - staggering vid ugnsrostning
+### Vegetables — staggering for oven roasting
 
-Olika grönsaker behöver olika tid. Lägg INTE in allt samtidigt!
+Different vegetables need different times. Do NOT put everything in at once!
 
-| Grönsak             | Ugntid vid 175°C varmluft |
-| ------------------- | ------------------------- |
-| Potatis (klyftor)   | 25-30 min                 |
-| Morötter (stavar)   | 20-25 min                 |
-| Lök (klyftor)       | 15-20 min                 |
-| Broccoli (buketter) | 12-15 min                 |
-| Zucchini (skivor)   | 10-15 min                 |
+| Vegetable          | Oven time at 175°C convection |
+| ------------------ | ----------------------------- |
+| Potatoes (wedges)  | 25-30 min                     |
+| Carrots (sticks)   | 20-25 min                     |
+| Onion (wedges)     | 15-20 min                     |
+| Broccoli (florets) | 12-15 min                     |
+| Zucchini (slices)  | 10-15 min                     |
 
-**Strategi för "allt på en plåt":**
+**Strategy for "everything on one tray":**
 
-1. Potatis + morötter in först (⏱️ 0 min)
-2. Broccoli + lök in efter 15 min (⏱️ 15 min)
-3. Allt klart samtidigt (⏱️ 30 min)
+1. Potatoes + carrots in first (⏱️ 0 min)
+2. Broccoli + onion in after 15 min (⏱️ 15 min)
+3. Everything done at the same time (⏱️ 30 min)
 
-### Smörtopping för airfryer-kyckling
+### Butter topping for air fryer chicken
 
-När kyckling vilar under folie efter airfryer:
+When chicken rests under foil after air fryer:
 
-- Lägg en klick smör och färska örter (timjan, rosmarin) på kycklingen
-- Smöret smälter och ger extra saftighet
-- Nämn detta som 💡-tips i instruktionerna
+- Place a knob of butter and fresh herbs (thyme, rosemary) on the chicken
+- The butter melts and adds extra juiciness
+- Mention this as a 💡 tip in instructions

--- a/config/prompts/user/language.md
+++ b/config/prompts/user/language.md
@@ -1,0 +1,9 @@
+# User Configuration - Language
+
+## Output language
+
+**All recipe text MUST be written in Swedish.**
+
+This includes: title, ingredients, instructions, tips, tags, category, cuisine, and changes_made.
+
+The JSON keys and field names are always in English — only the VALUES are in Swedish.

--- a/scripts/recipe_enhancer.py
+++ b/scripts/recipe_enhancer.py
@@ -124,18 +124,18 @@ def enhance_recipe(recipe: dict) -> dict | None:
     client = genai.Client(api_key=api_key)
 
     recipe_text = f"""
-Förbättra detta recept enligt reglerna:
+Enhance this recipe according to the rules:
 
-**Titel**: {recipe.get("title", "Okänd")}
+**Title**: {recipe.get("title", "Unknown")}
 
-**Ingredienser**:
+**Ingredients**:
 {chr(10).join(f"- {ing}" for ing in recipe.get("ingredients", []))}
 
-**Instruktioner**:
-{recipe.get("instructions", "Inga instruktioner")}
+**Instructions**:
+{recipe.get("instructions", "No instructions")}
 
-**Tips** (om finns):
-{recipe.get("tips", "Inga tips")}
+**Tips** (if any):
+{recipe.get("tips", "No tips")}
 """
 
     try:

--- a/scripts/test_gemini.py
+++ b/scripts/test_gemini.py
@@ -144,18 +144,18 @@ def enhance_recipe_with_gemini(recipe: dict) -> dict | None:
 
     # Format recipe for prompt
     recipe_text = f"""
-Förbättra detta recept enligt reglerna:
+Enhance this recipe according to the rules:
 
-**Titel**: {recipe.get("title", "Okänd")}
+**Title**: {recipe.get("title", "Unknown")}
 
-**Ingredienser**:
+**Ingredients**:
 {chr(10).join(f"- {ing}" for ing in recipe.get("ingredients", []))}
 
-**Instruktioner**:
-{recipe.get("instructions", "Inga instruktioner")}
+**Instructions**:
+{recipe.get("instructions", "No instructions")}
 
-**Tips** (om finns):
-{recipe.get("tips", "Inga tips")}
+**Tips** (if any):
+{recipe.get("tips", "No tips")}
 """
 
     try:

--- a/tests/test_recipe_enhancer.py
+++ b/tests/test_recipe_enhancer.py
@@ -100,19 +100,19 @@ class TestFormatRecipeText:
 
         result = _format_recipe_text(recipe)
 
-        assert "Titel: Test Recipe" in result
+        assert "Title: Test Recipe" in result
         assert "- 1 cup flour" in result
         assert "- 2 eggs" in result
         assert "Mix ingredients" in result
         assert "Bake at 180C" in result
 
     def test_handles_missing_title(self) -> None:
-        """Should use 'Okänd' for missing title."""
+        """Should use 'Unknown' for missing title."""
         recipe = {"ingredients": [], "instructions": []}
 
         result = _format_recipe_text(recipe)
 
-        assert "Titel: Okänd" in result
+        assert "Title: Unknown" in result
 
     def test_handles_string_instructions(self) -> None:
         """Should handle instructions as a single string."""


### PR DESCRIPTION
## Summary

Translate all Gemini enhancement prompts from Swedish to English and treat output language as a household setting.

## Changes

### Prompt translation (Swedish -> English)
- All 5 prompt files translated: `core/base.md`, `core/formatting.md`, `core/rules.md`, `user/dietary.md`, `user/equipment.md`
- Hardcoded Swedish strings in `scripts/recipe_enhancer.py` and `api/services/recipe_enhancer.py` translated
- Inline system prompt in `scripts/test_gemini.py` translated
- Test assertions updated for English format strings

### Household language setting (NEW)
- Created `config/prompts/user/language.md` as a household-level config (like dietary/equipment)
- Output language is now a household setting, NOT derived from input recipe language
- Registered in `prompt_loader.py` (loaded first, before dietary/equipment)
- Each household can specify their language independently

### Schema fixes
- Added `servings` to JSON schema (integer, NEVER null)
- Fixed `instructions` type: was documented as string, now correctly array of strings
- Added "Preserve numeric fields" section (servings, prep_time, cook_time, total_time)

### New enhancement rules
- **Quantity conservation**: when splitting ingredients, totals must equal the original
- **Every step must contain an action**: no empty header-only steps
- **High heat for searing**: mushrooms/meat on HIGH heat for Maillard reaction

## Validation

- All 344 tests pass
- Gemini dry-run on recipe S74yNqQ0aqV1TghZqHJx confirmed fixes:
  - Servings preserved (was null, now 4)
  - Oil quantity conserved (was 1 msk total from 2 msk, now correct)
  - Mushrooms on high heat (was medium)
  - 9 actionable steps (was 17 with empty headers)
  - Output in Swedish (household language setting)

## Backlog progress

This addresses items from the "Recipe Enhancer Overhaul" backlog:
- [x] Output recipes in household's configured language
- [ ] Read household settings from Firestore instead of static files (future)
- [ ] Split prompts: core (all users) vs user config (gitignored) (structure exists, gitignore TBD)
