### PR TITLE
fix: set Renovate rangeStrategy to replace

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigests",
     "docker:pinDigests"
   ],
+  "rangeStrategy": "replace",
   "rebaseWhen": "behind-base-branch",
   "branchPrefix": "renovate/",
   "labels": [


### PR DESCRIPTION
Prevents lockfile/manifest mismatch where Renovate updates the pnpm-lock.yaml specifier (e.g. ^12.0.0 to ^12.9.0) but leaves package.json unchanged, causing frozen-lockfile CI failures (see PR #161). Setting rangeStrategy to replace ensures Renovate always updates both package.json and the lockfile together.
