### PR TITLE
fix: add missing Firestore composite indexes for household queries

### DIFF
--- a/infra/modules/firestore/main.tf
+++ b/infra/modules/firestore/main.tf
@@ -105,6 +105,57 @@ resource "google_firestore_index" "recipes_by_diet_label" {
   }
 }
 
+# Recipes collection — household-scoped queries (owned recipes)
+resource "google_firestore_index" "recipes_by_household" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "recipes"
+
+  fields {
+    field_path = "household_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+# Recipes collection — shared recipe listing
+resource "google_firestore_index" "recipes_by_visibility" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "recipes"
+
+  fields {
+    field_path = "visibility"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+# Recipes collection — shared recipe count excluding own household
+resource "google_firestore_index" "recipes_shared_not_owned" {
+  project    = var.project
+  database   = google_firestore_database.meal_planner.name
+  collection = "recipes"
+
+  fields {
+    field_path = "visibility"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "household_id"
+    order      = "ASCENDING"
+  }
+}
+
 # Meal plans collection - query by week
 resource "google_firestore_index" "meal_plans_by_week" {
   project    = var.project


### PR DESCRIPTION
## Problem

Regular (non-superuser) household members saw **zero recipes** in the app, while superusers saw all 428. Meal planner showed 72 planned meals with raw recipe IDs instead of resolved recipe names.

## Root Cause

The household-scoped Firestore queries in recipe_queries.py combine `.where()` with `.order_by("created_at")`, which requires **composite indexes**. Without them, Firestore returns `FailedPrecondition: 400 The query requires an index`.

Superusers were unaffected because their query path has no `.where()` filter — just `order_by(created_at)`, which uses the built-in single-field index.

These queries were introduced in PR #164 (API performance optimization) but the corresponding Terraform index definitions were not added.

## Fix

Three composite indexes added to `infra/modules/firestore/main.tf`:

| Index | Fields | Used By |
|-------|--------|---------|
| `recipes_by_household` | household_id ASC + created_at DESC | Owned recipe listing |
| `recipes_by_visibility` | visibility ASC + created_at DESC | Shared recipe listing |
| `recipes_shared_not_owned` | visibility ASC + household_id ASC | count_recipes aggregation |

Indexes were created in production via gcloud CLI and imported into Terraform state. `terraform plan` shows no changes.

## Verification

- Ran diagnostic queries against real Firestore — all household-scoped queries now return correct results
- `count_recipes(household_id="IXdzHJ91NZeutylohx1t")` returns 428 (all recipes are shared)
- `get_recipes_paginated` returns recipe objects correctly for both households
- All 394 tests pass
