### PR TITLE
fix: masking loop exits on empty lines under bash -e

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -61,7 +61,9 @@ jobs:
           for f in access/superusers.txt access/users.txt terraform.tfvars; do
             if [ -f "$f" ]; then
               while IFS= read -r line; do
-                [ -n "$line" ] && echo "::add-mask::$line"
+                if [ -n "$line" ]; then
+                  echo "::add-mask::$line"
+                fi
               done < "$f"
             fi
           done


### PR DESCRIPTION
The masking loop in the reconstruct step uses `[ -n "$line" ] && echo "::add-mask::$line"` which returns exit code 1 on empty lines. Under `bash -e` (GitHub Actions default), this aborts the step.

**Root cause:** `terraform.tfvars` has empty lines between blocks. The `[ -n "" ]` test returns 1, and since it's the last command in the `&&` chain, bash sees a non-zero exit and stops.

**Fix:** Replace `[ test ] && cmd` with `if [ test ]; then cmd; fi` which has exit code 0 even when the condition is false.

Failed run: https://github.com/SkaneTrails/meal-planner/actions/runs/21839942825