### PR TITLE
chore: improve test coverage from 91% to 94%

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -222,6 +222,7 @@ See `pyproject.toml` for tool configurations.
 ### API (pytest)
 - New API endpoints → `tests/test_api_*.py`
 - New service functions → `tests/test_*.py`
+- **New model fields** → Test storage layer mapping (`_doc_to_recipe`, `_doc_to_*`)
 - Bug fixes → Include a test that covers the fixed behavior
 - Run: `uv run pytest --cov=api --cov-report=term-missing`
 
@@ -230,6 +231,12 @@ See `pyproject.toml` for tool configurations.
 - Auth/role-based behavior (permissions, navigation guards) → `mobile/app/__tests__/*.test.tsx`
 - Test utilities: `mobile/test/helpers.ts` (query wrapper, mock user factory)
 - Run: `cd mobile && pnpm test`
+
+### Pre-Commit Checklist
+Before committing changes that add new functionality:
+- [ ] Storage layer: Do mapping functions (`_doc_to_*`) include the new fields?
+- [ ] Are those mappings tested with explicit assertions?
+- [ ] Does coverage remain ≥90%? (`uv run pytest --cov=api`)
 
 **Exceptions:** Terraform, config files, pure UI styling.
 


### PR DESCRIPTION
## Summary

Improves API test coverage from 91% to 94% and updates instructions to prevent future coverage gaps.

## Instruction Changes

Added to Test Requirements section:
- **New model fields** → Test storage layer mapping (`_doc_to_recipe`, `_doc_to_*`)
- Pre-commit checklist for verifying mapping functions include new fields

This directly addresses the bug where `hidden` and `favorited` fields weren't mapped in `_doc_to_recipe`.

## Tests Added (18 new tests)

### household_storage.py (69% → 96%)
| Test | Function |
|------|----------|
| `test_returns_true_when_name_taken` | `household_name_exists` |
| `test_returns_false_when_name_not_taken` | `household_name_exists` |
| `test_allows_same_household_to_keep_name` | `household_name_exists` |
| `test_deletes_existing_household` | `delete_household` |
| `test_returns_false_for_nonexistent_household` | `delete_household` |
| `test_returns_none_for_nonexistent_household` | `get_household_settings` |
| `test_returns_empty_dict_when_no_settings` | `get_household_settings` |
| `test_returns_settings_when_exists` | `get_household_settings` |
| `test_returns_false_for_nonexistent_household` | `update_household_settings` |
| `test_updates_settings_with_merge` | `update_household_settings` |

### recipe_queries.py (79% → 93%)
| Test | Function |
|------|----------|
| `test_counts_all_recipes_for_superuser` | `count_recipes` |
| `test_counts_owned_and_shared_for_household` | `count_recipes` |
| `test_applies_hidden_filter_by_default` | `count_recipes` |
| `test_skips_hidden_filter_when_requested` | `count_recipes` |

### recipe_storage.py (85% → 92%)
| Test | Function |
|------|----------|
| `test_returns_false_when_not_owned_by_household` | `delete_recipe` |
| `test_deletes_when_owned_by_household` | `delete_recipe` |
| `test_returns_none_when_not_owned_by_household` | `update_recipe` |
| `test_updates_when_owned_by_household` | `update_recipe` |

## Coverage Summary

| Metric | Before | After |
|--------|--------|-------|
| **Overall** | 91% | **94%** |
| Tests | 470 | **488** |
