### PR TITLE
fix(mobile): use fontFamily for consistent fonts

### DIFF
--- a/mobile/components/RecipeCard.tsx
+++ b/mobile/components/RecipeCard.tsx
@@ -9,7 +9,7 @@ import { View, Text, Pressable, Animated } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
-import { colors, borderRadius, fontSize, fontWeight, letterSpacing, shadows } from '@/lib/theme';
+import { colors, borderRadius, fontSize, fontFamily, fontWeight, letterSpacing, shadows } from '@/lib/theme';
 import { useSettings } from '@/lib/settings-context';
 import { useTranslation } from '@/lib/i18n';
 import { hapticLight } from '@/lib/haptics';
@@ -100,7 +100,7 @@ export const RecipeCard = ({ recipe, onPress, compact = false, cardSize, showFav
           <View style={{ flex: 1, marginLeft: 16 }}>
             <Text style={{
               fontSize: 16,
-              fontWeight: '500',
+              fontFamily: fontFamily.bodyMedium,
               color: '#3D3D3D',
               letterSpacing: -0.2,
               lineHeight: 22,
@@ -119,7 +119,7 @@ export const RecipeCard = ({ recipe, onPress, compact = false, cardSize, showFav
                 }}>
                   <Text style={{
                     fontSize: 12,
-                    fontWeight: '500',
+                    fontFamily: fontFamily.bodyMedium,
                     color: recipe.diet_label === 'veggie' ? '#2F6B3B' :
                            recipe.diet_label === 'fish' ? '#1565C0' :
                            '#A0453D',
@@ -229,7 +229,7 @@ export const RecipeCard = ({ recipe, onPress, compact = false, cardSize, showFav
           {/* Title - 2 lines max */}
           <Text style={{
             fontSize: fontSize.md,
-            fontWeight: fontWeight.semibold,
+            fontFamily: fontFamily.bodySemibold,
             color: '#3D3228',
             lineHeight: 19,
           }} numberOfLines={2}>

--- a/mobile/components/recipes/RecipeFilters.tsx
+++ b/mobile/components/recipes/RecipeFilters.tsx
@@ -116,7 +116,7 @@ export const FilterChips = ({
         }}
       >
         <Text style={{
-          fontSize: 13, fontWeight: '600',
+          fontSize: 13, fontFamily: fontFamily.bodySemibold,
           color: !dietFilter && !showFavoritesOnly ? colors.white : '#5D4E40',
         }}>
           {t('labels.diet.all')}
@@ -140,7 +140,7 @@ export const FilterChips = ({
         >
           <Text style={{ fontSize: 13 }}>{emoji}</Text>
           <Text style={{
-            fontSize: 13, fontWeight: '600',
+            fontSize: 13, fontFamily: fontFamily.bodySemibold,
             color: dietFilter === diet ? colors.white : '#5D4E40',
           }}>
             {t(`labels.diet.${diet}`)}
@@ -167,7 +167,7 @@ export const FilterChips = ({
           color={showFavoritesOnly ? colors.white : '#C75050'}
         />
         <Text style={{
-          fontSize: 13, fontWeight: '600',
+          fontSize: 13, fontFamily: fontFamily.bodySemibold,
           color: showFavoritesOnly ? colors.white : '#5D4E40',
         }}>
           {t('recipes.favorites')}
@@ -187,7 +187,7 @@ export const FilterChips = ({
         }}
       >
         <Ionicons name="funnel-outline" size={13} color="#5D4E40" />
-        <Text style={{ fontSize: 13, fontWeight: '600', color: '#5D4E40' }}>
+                <Text style={{ fontSize: 13, fontFamily: fontFamily.bodySemibold, color: '#5D4E40' }}>
           {sortOptions.find((o) => o.value === sortBy)?.label}
         </Text>
       </AnimatedPressable>


### PR DESCRIPTION
## Problem
Recipe cards and filter chips were using `fontWeight: '500'` and `fontWeight: '600'` without specifying `fontFamily`, causing the deployed app to fall back to system fonts instead of DM Sans.

## Solution
Replaced string-based fontWeight with proper `fontFamily` references:
- `fontFamily.bodyMedium` for medium weight text
- `fontFamily.bodySemibold` for semibold text

## Files Changed
- `RecipeCard.tsx`: Fixed title and diet label fonts in both compact and grid views
- `RecipeFilters.tsx`: Fixed all filter chip label fonts

## Testing
- All 291 mobile tests pass