### PR TITLE
fix(mobile): load DM Sans via Google Fonts CSS for web

### DIFF
--- a/mobile/global.css
+++ b/mobile/global.css
@@ -1,3 +1,6 @@
+/* Import Google Fonts for web */
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/mobile/lib/theme.ts
+++ b/mobile/lib/theme.ts
@@ -4,7 +4,7 @@
  */
 
 export { colors, lightColors } from './theme/colors';
-export { fontFamily, fontSize, fontWeight, letterSpacing, typography } from './theme/typography';
+export { fontFamily, fontFamilyWeight, fontSize, fontWeight, letterSpacing, typography } from './theme/typography';
 export {
   spacing,
   layout,

--- a/mobile/lib/theme/typography.ts
+++ b/mobile/lib/theme/typography.ts
@@ -2,17 +2,38 @@
  * Typography scale, font families, weights, letter spacing, and presets.
  */
 
+import { Platform } from 'react-native';
+
 // Font families - DM Sans for everything (unified font)
+// Web uses CSS font names with weights, native uses Expo font names (which embed weight)
+const isWeb = Platform.OS === 'web';
+
+// For web: fontFamily is just the font name, weight comes from fontWeight
+// For native: fontFamily includes the weight (e.g., DMSans_600SemiBold)
 export const fontFamily = {
-  display: 'DMSans_600SemiBold',
-  displayRegular: 'DMSans_400Regular',
-  displayMedium: 'DMSans_500Medium',
-  displayBold: 'DMSans_700Bold',
-  body: 'DMSans_400Regular',
-  bodyMedium: 'DMSans_500Medium',
-  bodySemibold: 'DMSans_600SemiBold',
-  bodyBold: 'DMSans_700Bold',
-  accent: 'DMSans_500Medium',
+  display: isWeb ? '"DM Sans", sans-serif' : 'DMSans_600SemiBold',
+  displayRegular: isWeb ? '"DM Sans", sans-serif' : 'DMSans_400Regular',
+  displayMedium: isWeb ? '"DM Sans", sans-serif' : 'DMSans_500Medium',
+  displayBold: isWeb ? '"DM Sans", sans-serif' : 'DMSans_700Bold',
+  body: isWeb ? '"DM Sans", sans-serif' : 'DMSans_400Regular',
+  bodyMedium: isWeb ? '"DM Sans", sans-serif' : 'DMSans_500Medium',
+  bodySemibold: isWeb ? '"DM Sans", sans-serif' : 'DMSans_600SemiBold',
+  bodyBold: isWeb ? '"DM Sans", sans-serif' : 'DMSans_700Bold',
+  accent: isWeb ? '"DM Sans", sans-serif' : 'DMSans_500Medium',
+};
+
+// Font weights - used in addition to fontFamily for web
+// On native, fontFamily already includes weight, so these are redundant but harmless
+export const fontFamilyWeight = {
+  display: '600' as const,
+  displayRegular: '400' as const,
+  displayMedium: '500' as const,
+  displayBold: '700' as const,
+  body: '400' as const,
+  bodyMedium: '500' as const,
+  bodySemibold: '600' as const,
+  bodyBold: '700' as const,
+  accent: '500' as const,
 };
 
 // Typography scale - refined for luxury feel


### PR DESCRIPTION
## Problem
Fonts were not displaying correctly in the deployed web app. The Expo font loading works for native but doesn't properly load fonts via CSS for web builds.

## Solution
- Added Google Fonts `@import` in `global.css` for the web platform
- Updated `fontFamily` in typography to use CSS-compatible font names (`"DM Sans", sans-serif`) on web
- Kept Expo font names (`DMSans_600SemiBold` etc) for native platforms using `Platform.OS` check
- Added `fontFamilyWeight` export for explicit weight control on web

## Testing
- All 291 mobile tests pass