### PR TITLE
fix: include config/prompts in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,9 @@ COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 
-# Copy application code
+# Copy application code and configuration
 COPY api/ ./api/
+COPY config/ ./config/
 
 # Cloud Run sets PORT environment variable
 ENV PORT=8080

--- a/api/services/prompt_loader.py
+++ b/api/services/prompt_loader.py
@@ -93,6 +93,11 @@ def load_system_prompt(language: str = DEFAULT_LANGUAGE) -> str:
 
     parts = [p for p in (core, locale, user) if p]
 
+    if not parts:
+        prompts_dir = get_prompts_dir()
+        msg = f"No prompt files found — prompts directory may be missing: {prompts_dir}"
+        raise FileNotFoundError(msg)
+
     return "\n\n---\n\n".join(parts)
 
 

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from api.services.prompt_loader import (
     DEFAULT_LANGUAGE,
     LANGUAGE_NAMES,
@@ -251,6 +253,16 @@ class TestLoadSystemPrompt:
             result = load_system_prompt("en")
 
         assert "Output in English" in result
+
+    def test_raises_when_no_prompt_files_found(self, tmp_path: Path) -> None:
+        """Should raise FileNotFoundError when prompts directory is missing."""
+        empty_dir = tmp_path / "missing" / "prompts"
+
+        with (
+            patch("api.services.prompt_loader.get_prompts_dir", return_value=empty_dir),
+            pytest.raises(FileNotFoundError, match="No prompt files found"),
+        ):
+            load_system_prompt()
 
 
 class TestValidatePrompts:


### PR DESCRIPTION
## Problem

When enhancing recipe kmSjOUFlQyDkPUDGCmpV via the API, Gemini returned English text instead of Italian despite the household language being set to "it".

## Root Cause

The Dockerfile only copied `api/` into the container image — `config/prompts/` was never included. At runtime in Cloud Run, `prompt_loader.py` resolved the prompts directory to `/app/config/prompts/` which didn't exist. Since `load_prompt_file()` silently returns `""` for missing files, Gemini received an **empty system prompt** with no language instructions, formatting rules, or locale-specific content.

Without any instructions, Gemini defaulted to the input language (English, since the recipe was scraped from the English version of GialloZafferano).

## Changes

### Dockerfile
- Add `COPY config/ ./config/` so prompt files are included in the container image

### api/services/prompt_loader.py
- `load_system_prompt()` now raises `FileNotFoundError` when all prompt parts are empty, preventing silent degradation to an empty system prompt

### tests/test_prompt_loader.py
- Add test for the new guard (empty prompts dir raises `FileNotFoundError`)

## Testing
- All 513 tests pass
- Pre-commit hooks pass (ruff, ty, biome, prettier)
