### PR TITLE
fix: snapshot original recipe data before enhancement overwrite

### DIFF
--- a/api/storage/recipe_storage.py
+++ b/api/storage/recipe_storage.py
@@ -155,16 +155,31 @@ def save_recipe(
         if existing.exists:
             existing_data = existing.to_dict() or {}
             existing_created_at = existing_data.get("created_at")
-            original_snapshot = OriginalRecipe(
-                title=existing_data.get("title", ""),
-                ingredients=existing_data.get("ingredients", []),
-                instructions=existing_data.get("instructions", []),
-                servings=existing_data.get("servings"),
-                prep_time=existing_data.get("prep_time"),
-                cook_time=existing_data.get("cook_time"),
-                total_time=existing_data.get("total_time"),
-                image_url=existing_data.get("image_url"),
-            )
+
+            # Reuse preserved original snapshot if recipe was already enhanced
+            existing_original = existing_data.get("original")
+            if isinstance(existing_original, dict) and existing_original:
+                original_snapshot = OriginalRecipe(
+                    title=existing_original.get("title", ""),
+                    ingredients=existing_original.get("ingredients", []),
+                    instructions=existing_original.get("instructions", []),
+                    servings=existing_original.get("servings"),
+                    prep_time=existing_original.get("prep_time"),
+                    cook_time=existing_original.get("cook_time"),
+                    total_time=existing_original.get("total_time"),
+                    image_url=existing_original.get("image_url"),
+                )
+            else:
+                original_snapshot = OriginalRecipe(
+                    title=existing_data.get("title", ""),
+                    ingredients=existing_data.get("ingredients", []),
+                    instructions=existing_data.get("instructions", []),
+                    servings=existing_data.get("servings"),
+                    prep_time=existing_data.get("prep_time"),
+                    cook_time=existing_data.get("cook_time"),
+                    total_time=existing_data.get("total_time"),
+                    image_url=existing_data.get("image_url"),
+                )
 
     now = datetime.now(tz=UTC)
     created_at = existing_created_at if existing_created_at else now
@@ -205,7 +220,7 @@ def save_recipe(
     if original_snapshot:
         data["original"] = original_snapshot.model_dump()
 
-    doc_ref.set(data)
+    doc_ref.set(data, merge=True)
 
     # Type cast visibility to match Recipe model's Literal type
     visibility_value = data["visibility"]


### PR DESCRIPTION
## Problem

When a recipe is enhanced, save_recipe() overwrites the Firestore document with .set() without preserving the original data. This means:

- The original nested field is never populated
- The mobile app toggle between original/enhanced versions never appears (hasOriginal = Boolean(recipe.enhanced && recipe.original) is always false)
- The original created_at timestamp is lost

## Root Cause

save_recipe() performs a full .set() overwrite without first reading the existing document. The Firestore schema requires snapshotting original data into the original nested field on enhancement.

## Fix

- Before overwriting with enhanced data, read the existing Firestore document
- Snapshot original title, ingredients, instructions, servings, times, and image_url into an OriginalRecipe model stored in the original field
- Preserve the existing created_at timestamp
- Set show_enhanced=False and enhancement_reviewed=False for the review flow

## Tests

- Updated test_saves_enhancement_fields to mock existing document read
- Added test_snapshots_original_on_enhancement - verifies original data captured
- Added test_preserves_created_at_on_enhancement - verifies timestamp preserved
- Added test_no_original_snapshot_for_new_recipe - no snapshot when no recipe_id

All 516 tests pass.
