### PR TITLE
fix: security hardening — Dockerfile non-root user and mobile error sanitization

### DIFF
--- a/mobile/lib/hooks/useGroceryScreen.ts
+++ b/mobile/lib/hooks/useGroceryScreen.ts
@@ -128,11 +128,11 @@ export const useGroceryScreen = () => {
       AsyncStorage.setItem(
         'grocery_custom_items',
         JSON.stringify(customItems),
-      ).catch(
-        (error) =>
-          __DEV__ &&
-          console.error('[Grocery] Error saving custom items:', error),
-      );
+      ).catch((error) => {
+        if (__DEV__) {
+          console.error('[Grocery] Error saving custom items:', error);
+        }
+      });
     }
   }, [customItems, isLoading]);
 


### PR DESCRIPTION
## Summary

Security hardening across Docker and mobile client.

## Changes

### Dockerfile hardening
- Add non-root `appuser` system user with `chown -R` and `USER` directive
- Update `.dockerignore` with comprehensive exclusions (`.git/`, `.github/`, `.venv/`, `tests/`, `data/`, `mobile/`, `infra/`, etc.)
- Fix `.gitignore`: remove `.dockerignore` entry (must be tracked for consistent builds), add `.tmp_git_*.sh` pattern

### Mobile security fixes (12 files)

| Category | Impact | Files |
|---|---|---|
| **Raw error messages** | HIGH — `error.message` from Firebase/API was shown to users | `use-auth.tsx`, `admin.tsx`, `household-settings.tsx` |
| **Auth logging** | MEDIUM — credentials/tokens logged in production | `use-auth.tsx`, `sign-in.tsx` |
| **PII in cache** | MEDIUM — `currentUser` (email, role) persisted to unencrypted AsyncStorage | `query-provider.tsx` |
| **console.error guards** | LOW — stack traces in production builds | `grocery.tsx`, `settings-context.tsx`, `ErrorBoundary.tsx` |

**Approach:**
- Replace `error.message` with i18n keys (`signInFailed`, `noIdToken`, etc.) — never expose raw errors to users
- Error codes from `use-auth.tsx` are mapped to translations in `sign-in.tsx` via `t('signIn.${error}')`
- All `console.error` calls guarded with `__DEV__` checks
- `admin.currentUser` query excluded from AsyncStorage persistence
- New i18n keys added in all 3 locales (en/sv/it)

## Testing

- All 310 mobile tests pass
- Updated `sign-in.test.tsx` to verify new error code pattern
