### PR TITLE
refactor: extract FullScreenLoading component from 7 screens

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -6,11 +6,10 @@
  */
 
 import { Redirect, Tabs } from 'expo-router';
-import { ActivityIndicator, View } from 'react-native';
+import { FullScreenLoading } from '@/components';
 import { useCurrentUser } from '@/lib/hooks/use-admin';
 import { useAuth } from '@/lib/hooks/use-auth';
 import { useTranslation } from '@/lib/i18n';
-import { colors } from '@/lib/theme';
 
 export default function TabLayout() {
   const { user, loading } = useAuth();
@@ -20,18 +19,7 @@ export default function TabLayout() {
   });
 
   if (loading) {
-    return (
-      <View
-        style={{
-          flex: 1,
-          justifyContent: 'center',
-          alignItems: 'center',
-          backgroundColor: colors.bgLight,
-        }}
-      >
-        <ActivityIndicator size="large" color={colors.accent} />
-      </View>
-    );
+    return <FullScreenLoading background="muted" />;
   }
 
   if (!user) {
@@ -39,18 +27,7 @@ export default function TabLayout() {
   }
 
   if (userLoading) {
-    return (
-      <View
-        style={{
-          flex: 1,
-          justifyContent: 'center',
-          alignItems: 'center',
-          backgroundColor: 'white',
-        }}
-      >
-        <ActivityIndicator size="large" color="#10b981" />
-      </View>
-    );
+    return <FullScreenLoading background="muted" />;
   }
 
   // If API returns error (likely 403 - user not in any household), redirect to no-access

--- a/mobile/app/(tabs)/admin.tsx
+++ b/mobile/app/(tabs)/admin.tsx
@@ -7,14 +7,12 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
+import { FlatList, RefreshControl, Text, View } from 'react-native';
 import {
-  ActivityIndicator,
-  FlatList,
-  RefreshControl,
-  Text,
-  View,
-} from 'react-native';
-import { AnimatedPressable, GradientBackground } from '@/components';
+  AnimatedPressable,
+  FullScreenLoading,
+  GradientBackground,
+} from '@/components';
 import {
   CreateHouseholdModal,
   HouseholdCard,
@@ -56,52 +54,17 @@ export default function AdminScreen() {
   const [newHouseholdName, setNewHouseholdName] = useState('');
 
   if (userLoading) {
-    return (
-      <GradientBackground muted>
-        <View
-          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-        >
-          <ActivityIndicator size="large" color={colors.primary} />
-        </View>
-      </GradientBackground>
-    );
+    return <FullScreenLoading background="muted" />;
   }
 
   if (!currentUser || currentUser.role !== 'superuser') {
     return (
-      <GradientBackground muted>
-        <View
-          style={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            padding: spacing.xl,
-          }}
-        >
-          <Ionicons name="lock-closed" size={64} color={colors.text.muted} />
-          <Text
-            style={{
-              fontSize: fontSize['2xl'],
-              fontWeight: fontWeight.semibold,
-              color: colors.text.muted,
-              marginTop: spacing.lg,
-              textAlign: 'center',
-            }}
-          >
-            {t('admin.accessRequired')}
-          </Text>
-          <Text
-            style={{
-              fontSize: fontSize.lg,
-              color: colors.text.muted,
-              marginTop: spacing.sm,
-              textAlign: 'center',
-            }}
-          >
-            {t('admin.accessRequiredMessage')}
-          </Text>
-        </View>
-      </GradientBackground>
+      <FullScreenLoading
+        background="muted"
+        icon="lock-closed"
+        title={t('admin.accessRequired')}
+        subtitle={t('admin.accessRequiredMessage')}
+      />
     );
   }
 

--- a/mobile/app/household-settings.tsx
+++ b/mobile/app/household-settings.tsx
@@ -6,14 +6,8 @@
 
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
-import {
-  ActivityIndicator,
-  ScrollView,
-  Switch,
-  Text,
-  View,
-} from 'react-native';
-import { GradientBackground } from '@/components';
+import { ActivityIndicator, ScrollView, Switch, View } from 'react-native';
+import { FullScreenLoading, GradientBackground } from '@/components';
 import {
   AiSection,
   CollapsibleSection,
@@ -71,24 +65,13 @@ export default function HouseholdSettingsScreen() {
 
   if (!form.householdId) {
     if (form.userLoading) {
-      return (
-        <GradientBackground muted>
-          <View
-            style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-          >
-            <ActivityIndicator size="large" color={colors.accent} />
-          </View>
-        </GradientBackground>
-      );
+      return <FullScreenLoading background="muted" />;
     }
     return (
-      <GradientBackground muted>
-        <View
-          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-        >
-          <Text>{t('householdSettings.invalidHouseholdId')}</Text>
-        </View>
-      </GradientBackground>
+      <FullScreenLoading
+        background="muted"
+        title={t('householdSettings.invalidHouseholdId')}
+      />
     );
   }
 

--- a/mobile/app/no-access.tsx
+++ b/mobile/app/no-access.tsx
@@ -5,8 +5,8 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import { Redirect, useRouter } from 'expo-router';
-import { ActivityIndicator, Pressable, Text, View } from 'react-native';
-import { GradientBackground } from '@/components';
+import { Pressable, Text, View } from 'react-native';
+import { FullScreenLoading, GradientBackground } from '@/components';
 import { showNotification } from '@/lib/alert';
 import { useCurrentUser } from '@/lib/hooks/use-admin';
 import { useAuth } from '@/lib/hooks/use-auth';
@@ -45,14 +45,7 @@ export default function NoAccessScreen() {
   }
 
   if (loading || userLoading) {
-    return (
-      <GradientBackground
-        animated
-        style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}
-      >
-        <ActivityIndicator size="large" color={colors.primary} />
-      </GradientBackground>
-    );
+    return <FullScreenLoading background="animated" />;
   }
 
   return (

--- a/mobile/app/review-recipe.tsx
+++ b/mobile/app/review-recipe.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { GradientBackground } from '@/components';
+import { FullScreenLoading, GradientBackground } from '@/components';
 import {
   DIET_OPTIONS,
   MEAL_OPTIONS,
@@ -68,15 +68,7 @@ export default function ReviewRecipeScreen() {
   const [mealLabel, setMealLabel] = useState<MealLabel | null>(null);
 
   if (!preview) {
-    return (
-      <GradientBackground
-        style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-      >
-        <Text style={{ color: colors.text.inverse, fontSize: fontSize.xl }}>
-          {t('common.error')}
-        </Text>
-      </GradientBackground>
-    );
+    return <FullScreenLoading title={t('common.error')} />;
   }
 
   const selectedRecipe: RecipeCreate =

--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -4,8 +4,8 @@
  */
 
 import { Redirect } from 'expo-router';
-import { ActivityIndicator, Pressable, Text, View } from 'react-native';
-import { GradientBackground } from '../components';
+import { Pressable, Text, View } from 'react-native';
+import { FullScreenLoading, GradientBackground } from '../components';
 import { GoogleLogo } from '../components/GoogleLogo';
 import { useAuth } from '../lib/hooks/use-auth';
 import { useTranslation } from '../lib/i18n';
@@ -37,11 +37,7 @@ export default function SignInScreen() {
 
   if (loading) {
     return (
-      <GradientBackground
-        animated
-        style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}
-      >
-        <ActivityIndicator size="large" color={colors.primary} />
+      <FullScreenLoading background="animated">
         <Pressable
           onPress={handleSignOut}
           style={({ pressed }) => ({
@@ -54,7 +50,7 @@ export default function SignInScreen() {
         >
           <Text
             style={{
-              color: 'rgba(255, 255, 255, 0.6)',
+              color: colors.glass.subtle,
               fontSize: fontSize.sm,
               fontFamily: fontFamily.body,
               textDecorationLine: 'underline',
@@ -63,7 +59,7 @@ export default function SignInScreen() {
             {t('signIn.signOut')}
           </Text>
         </Pressable>
-      </GradientBackground>
+      </FullScreenLoading>
     );
   }
 

--- a/mobile/components/FullScreenLoading.tsx
+++ b/mobile/components/FullScreenLoading.tsx
@@ -1,0 +1,87 @@
+/**
+ * Full-screen loading spinner or message state.
+ * Wraps GradientBackground with centered content for loading, error, and info screens.
+ *
+ * Usage:
+ *   <FullScreenLoading background="muted" />                          — spinner
+ *   <FullScreenLoading background="muted" icon="lock-closed" ... />   — message with icon
+ */
+
+import type { Ionicons as IoniconsType } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons';
+import type { ComponentProps, ReactNode } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { GradientBackground } from '@/components/GradientBackground';
+import { colors, fontFamily, fontSize, spacing } from '@/lib/theme';
+
+interface FullScreenLoadingProps {
+  /** GradientBackground visual mode (default: 'default') */
+  background?: 'default' | 'muted' | 'animated';
+  /** Ionicons name — shows icon instead of spinner */
+  icon?: ComponentProps<typeof IoniconsType>['name'];
+  /** Primary message text */
+  title?: string;
+  /** Secondary message text */
+  subtitle?: string;
+  /** Extra content rendered below the main content (e.g., action buttons) */
+  children?: ReactNode;
+}
+
+const bgVariant = (bg: FullScreenLoadingProps['background']) => ({
+  muted: bg === 'muted',
+  animated: bg === 'animated',
+});
+
+export const FullScreenLoading = ({
+  background = 'default',
+  icon,
+  title,
+  subtitle,
+  children,
+}: FullScreenLoadingProps) => {
+  const isMessage = Boolean(icon || title);
+
+  return (
+    <GradientBackground {...bgVariant(background)} style={styles.container}>
+      {isMessage ? (
+        <View style={styles.content}>
+          {icon && <Ionicons name={icon} size={64} color={colors.text.muted} />}
+          {title && (
+            <Text style={[styles.title, icon && { marginTop: spacing.lg }]}>
+              {title}
+            </Text>
+          )}
+          {subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+        </View>
+      ) : (
+        <ActivityIndicator size="large" color={colors.primary} />
+      )}
+      {children}
+    </GradientBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  title: {
+    fontSize: fontSize['2xl'],
+    fontFamily: fontFamily.bodySemibold,
+    color: colors.text.muted,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: fontSize.lg,
+    fontFamily: fontFamily.body,
+    color: colors.text.muted,
+    marginTop: spacing.sm,
+    textAlign: 'center',
+  },
+});

--- a/mobile/components/index.ts
+++ b/mobile/components/index.ts
@@ -10,6 +10,7 @@ export { EnhancingOverlay } from './EnhancingOverlay';
 export { ErrorBoundary } from './ErrorBoundary';
 export { FilterChip } from './FilterChip';
 export { FloatingTabBar } from './FloatingTabBar';
+export { FullScreenLoading } from './FullScreenLoading';
 export { GradientBackground } from './GradientBackground';
 export { GroceryItemRow } from './GroceryItemRow';
 export { GroceryListView } from './GroceryListView';

--- a/mobile/test/setup.ts
+++ b/mobile/test/setup.ts
@@ -64,9 +64,31 @@ vi.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }: any) => children,
 }));
 
+// Mock @/components/FullScreenLoading (must mock separately to prevent real module from loading GradientBackground)
+vi.mock('@/components/FullScreenLoading', () => ({
+  FullScreenLoading: ({ children, title, subtitle, icon }: any) => {
+    const { createElement } = require('react');
+    return createElement('div', { 'data-testid': 'fullscreen-loading' },
+      icon && createElement('span', { 'data-testid': 'fullscreen-icon' }, icon),
+      title && createElement('span', null, title),
+      subtitle && createElement('span', null, subtitle),
+      children,
+    );
+  },
+}));
+
 // Mock @/components (GradientBackground, etc.)
 vi.mock('@/components', () => ({
   GradientBackground: ({ children }: any) => children,
+  FullScreenLoading: ({ children, title, subtitle, icon }: any) => {
+    const { createElement } = require('react');
+    return createElement('div', { 'data-testid': 'fullscreen-loading' },
+      icon && createElement('span', { 'data-testid': 'fullscreen-icon' }, icon),
+      title && createElement('span', null, title),
+      subtitle && createElement('span', null, subtitle),
+      children,
+    );
+  },
   AnimatedPressable: ({ children, onPress, ...props }: any) => {
     const { createElement } = require('react');
     return createElement('button', { onClick: onPress, ...props }, children);


### PR DESCRIPTION
## Summary

Extract a reusable `FullScreenLoading` component to replace 9 inline loading/error/info patterns across 7 screen files. This is **Phase C** of the UI consistency refactoring (following ScreenTitle in PR #250).

## Changes

### New component: `FullScreenLoading`
- **Loading mode** (default): `ActivityIndicator` spinner on a `GradientBackground`
- **Message mode**: Icon + title + optional subtitle (for error/access-denied states)
- Props: `background` (`default` | `muted` | `animated`), `icon`, `title`, `subtitle`, `children`
- Uses theme tokens throughout (no hardcoded colors)

### Screens updated (9 replacements in 7 files)
| Screen | Before | After |
|--------|--------|-------|
| `_layout.tsx` (x2) | Plain `View` with hardcoded `#10b981`, `white`, `bgLight` | `<FullScreenLoading background="muted" />` |
| `admin.tsx` (x2) | `GradientBackground` + `ActivityIndicator` / lock icon + text | `<FullScreenLoading>` with spinner / icon+message |
| `household-settings.tsx` (x2) | Inline spinner / "invalid ID" text | `<FullScreenLoading>` variants |
| `sign-in.tsx` | Inline spinner + sign-out button | `<FullScreenLoading>` with `children` for sign-out |
| `no-access.tsx` | Inline spinner | `<FullScreenLoading background="animated" />` |
| `review-recipe.tsx` | Inline error text | `<FullScreenLoading title={error} />` |

### Theme violations fixed
- `_layout.tsx`: Removed hardcoded `#10b981`, `'white'`, `colors.bgLight`
- `sign-in.tsx`: `rgba(255, 255, 255, 0.6)` replaced with `colors.glass.subtle`

### Stats
- **+142 / -128 lines** (net +14 with the new component, net -114 boilerplate across screens)
- All 472 mobile tests pass
- TypeScript clean, Biome clean
