### PR TITLE
refactor: extract ColorTokens and FontFamilyTokens types from theme

### DIFF
--- a/mobile/lib/theme.ts
+++ b/mobile/lib/theme.ts
@@ -3,6 +3,7 @@
  * Re-exports all theme modules for a unified import surface.
  */
 
+export type { ColorTokens } from './theme/colors';
 export { colors, lightColors } from './theme/colors';
 export {
   animation,
@@ -23,6 +24,7 @@ export {
   settingsSubtitleStyle,
   settingsTitleStyle,
 } from './theme/styles';
+export type { FontFamilyTokens } from './theme/typography';
 export {
   fontFamily,
   fontFamilyWeight,

--- a/mobile/lib/theme/colors.ts
+++ b/mobile/lib/theme/colors.ts
@@ -2,6 +2,13 @@
  * Color palette - luxurious design system with elegant warm tones.
  */
 
+/** Recursively widen color literal types to `string` for structural contracts. */
+type WidenColors<T> = T extends readonly string[]
+  ? readonly string[]
+  : T extends string
+    ? string
+    : { readonly [K in keyof T]: WidenColors<T[K]> };
+
 export const lightColors = {
   // Primary - Elegant dark charcoal
   primary: '#2D2D2D',
@@ -253,6 +260,9 @@ export const lightColors = {
     '#6B8FA3', // slate blue
   ] as readonly string[],
 } as const;
+
+/** Structural contract that every color palette must satisfy. */
+export type ColorTokens = WidenColors<typeof lightColors>;
 
 // Export colors (light theme only)
 export const colors = lightColors;

--- a/mobile/lib/theme/typography.ts
+++ b/mobile/lib/theme/typography.ts
@@ -4,6 +4,11 @@
 
 import { Platform } from 'react-native';
 
+/** Structural contract for font family mappings. */
+export type FontFamilyTokens = {
+  readonly [K in keyof typeof fontFamily]: string;
+};
+
 // Font families - DM Sans for everything (unified font)
 // Web uses CSS font names with weights, native uses Expo font names (which embed weight)
 const isWeb = Platform.OS === 'web';


### PR DESCRIPTION
## Summary

Extract structural type contracts from the theme system as pure preparation
for future multi-theme support. No runtime changes, no UI changes, no theming
engine — just TypeScript types.

## Changes

### `mobile/lib/theme/colors.ts`
- `WidenColors<T>` — recursive utility type that widens narrow string literal
  types (e.g. `'#2D2D2D'`) to `string`, handles nested objects and
  `readonly string[]`
- `ColorTokens` — the structural contract derived from `typeof lightColors`
  via `WidenColors`. Any future color palette must satisfy this shape

### `mobile/lib/theme/typography.ts`
- `FontFamilyTokens` — mapped type keyed off `fontFamily`, requiring each slot
  to be a `string`. Any future font family mapping must satisfy this shape

### `mobile/lib/theme.ts`
- Re-exports both types via `export type`

## What this does NOT include

- No ThemeProvider / ThemeContext / useTheme()
- No theme toggle UI
- No terminal theme or alternate palette
- No runtime changes — types are erased at compile time
- No changes to how components consume colors/typography

## Verification

- 545/545 mobile tests pass
- TypeScript compiles clean
- All pre-commit hooks pass
- Zero bundle size impact (types are erased)
