### PR TITLE
refactor: migrate remaining static colors to useTheme()

### DIFF
--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -11,13 +11,14 @@ import { useAuth } from '../lib/hooks/use-auth';
 import { useTranslation } from '../lib/i18n';
 import {
   borderRadius,
-  colors,
   fontFamily,
   fontSize,
   spacing,
+  useTheme,
 } from '../lib/theme';
 
 export default function SignInScreen() {
+  const { colors } = useTheme();
   const { user, loading, error, signIn, signOut } = useAuth();
   const { t } = useTranslation();
 

--- a/mobile/components/ScreenTitle.tsx
+++ b/mobile/components/ScreenTitle.tsx
@@ -1,12 +1,12 @@
 import type { StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, Text, View } from 'react-native';
 import {
-  colors,
   fontFamily,
   fontSize,
   fontWeight,
   letterSpacing,
   spacing,
+  useTheme,
 } from '@/lib/theme';
 
 interface ScreenTitleProps {
@@ -22,16 +22,34 @@ export const ScreenTitle = ({
   variant = 'centered',
   style,
 }: ScreenTitleProps) => {
+  const { colors } = useTheme();
   const isCentered = variant === 'centered';
 
   return (
     <View style={style}>
-      <Text style={isCentered ? styles.centeredTitle : styles.largeTitle}>
+      <Text
+        style={[
+          isCentered ? styles.centeredTitle : styles.largeTitle,
+          isCentered
+            ? { color: colors.content.heading }
+            : {
+                color: colors.text.primary,
+                textShadowColor: colors.shadow.text,
+              },
+        ]}
+      >
         {title}
       </Text>
       {subtitle && (
         <Text
-          style={isCentered ? styles.centeredSubtitle : styles.largeSubtitle}
+          style={[
+            isCentered ? styles.centeredSubtitle : styles.largeSubtitle,
+            {
+              color: isCentered
+                ? colors.content.subtitle
+                : colors.text.secondary,
+            },
+          ]}
         >
           {subtitle}
         </Text>
@@ -45,30 +63,25 @@ const styles = StyleSheet.create({
     fontSize: fontSize['3xl'],
     fontFamily: fontFamily.displayBold,
     fontWeight: fontWeight.bold,
-    color: colors.content.heading,
     letterSpacing: letterSpacing.tight,
     textAlign: 'center',
   },
   centeredSubtitle: {
     fontSize: fontSize.md,
     fontFamily: fontFamily.body,
-    color: colors.content.subtitle,
     marginTop: spacing['2xs'],
     textAlign: 'center',
   },
   largeTitle: {
     fontSize: fontSize['4xl'],
     fontFamily: fontFamily.display,
-    color: colors.text.primary,
     letterSpacing: letterSpacing.tight,
-    textShadowColor: colors.shadow.text,
     textShadowOffset: { width: 1, height: 1 },
     textShadowRadius: 2,
   },
   largeSubtitle: {
     fontSize: fontSize.lg,
     fontFamily: fontFamily.body,
-    color: colors.text.secondary,
     letterSpacing: letterSpacing.normal,
     marginTop: spacing.xs,
   },

--- a/mobile/components/meal-plan/CollapsedDayRow.tsx
+++ b/mobile/components/meal-plan/CollapsedDayRow.tsx
@@ -3,12 +3,12 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
 import {
   borderRadius,
-  colors,
   fontSize,
   fontWeight,
   iconSize,
   shadows,
   spacing,
+  useTheme,
 } from '@/lib/theme';
 import { toBcp47 } from '@/lib/utils/dateFormatter';
 
@@ -27,6 +27,7 @@ export const CollapsedDayRow = ({
   t,
   onExpand,
 }: CollapsedDayRowProps) => {
+  const { colors } = useTheme();
   const bcp47 = toBcp47(language);
   const dayName = date.toLocaleDateString(bcp47, { weekday: 'short' });
   const monthDay = date.toLocaleDateString(bcp47, {
@@ -39,13 +40,22 @@ export const CollapsedDayRow = ({
       : t('mealPlan.noMeals');
 
   return (
-    <Pressable onPress={onExpand} style={styles.container}>
+    <Pressable
+      onPress={onExpand}
+      style={[styles.container, { backgroundColor: colors.glass.card }]}
+    >
       <View style={styles.left}>
-        <Text style={styles.dayName}>{dayName}</Text>
-        <Text style={styles.monthDay}>{monthDay}</Text>
+        <Text style={[styles.dayName, { color: colors.content.body }]}>
+          {dayName}
+        </Text>
+        <Text style={[styles.monthDay, { color: colors.content.subtitle }]}>
+          {monthDay}
+        </Text>
       </View>
       <View style={styles.right}>
-        <Text style={styles.summary}>{summary}</Text>
+        <Text style={[styles.summary, { color: colors.content.icon }]}>
+          {summary}
+        </Text>
         <Ionicons
           name="chevron-down"
           size={iconSize.sm}
@@ -61,7 +71,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.glass.card,
     borderRadius: borderRadius.sm,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
@@ -81,15 +90,12 @@ const styles = StyleSheet.create({
   dayName: {
     fontSize: fontSize.md,
     fontWeight: fontWeight.semibold,
-    color: colors.content.body,
     textTransform: 'capitalize',
   },
   monthDay: {
     fontSize: fontSize.md,
-    color: colors.content.subtitle,
   },
   summary: {
     fontSize: fontSize.sm,
-    color: colors.content.icon,
   },
 });

--- a/mobile/components/recipes/RecipeFilters.tsx
+++ b/mobile/components/recipes/RecipeFilters.tsx
@@ -10,11 +10,11 @@ import { hapticLight } from '@/lib/haptics';
 import type { TFunction } from '@/lib/i18n';
 import {
   borderRadius,
-  colors,
   dotSize,
   fontFamily,
   fontSize,
   spacing,
+  useTheme,
 } from '@/lib/theme';
 import type { DietLabel, LibraryScope } from '@/lib/types';
 
@@ -38,60 +38,64 @@ export const SearchBar = ({
   onClear,
   searchInputRef,
   t,
-}: SearchBarProps) => (
-  <View style={{ paddingHorizontal: spacing.xl, paddingBottom: spacing.sm }}>
-    <View
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        backgroundColor: colors.glass.light,
-        borderRadius: borderRadius.md,
-        paddingHorizontal: spacing.md,
-        paddingVertical: spacing.sm,
-        borderWidth: 1,
-        borderColor: colors.glass.border,
-      }}
-    >
-      <Ionicons name="search" size={18} color={colors.content.secondary} />
-      <TextInput
-        ref={searchInputRef}
+}: SearchBarProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ paddingHorizontal: spacing.xl, paddingBottom: spacing.sm }}>
+      <View
         style={{
-          flex: 1,
-          fontSize: fontSize.md,
-          color: colors.content.body,
-          marginLeft: spacing.sm,
+          flexDirection: 'row',
+          alignItems: 'center',
+          backgroundColor: colors.glass.light,
+          borderRadius: borderRadius.md,
+          paddingHorizontal: spacing.md,
+          paddingVertical: spacing.sm,
+          borderWidth: 1,
+          borderColor: colors.glass.border,
         }}
-        placeholder={t('recipes.searchPlaceholder')}
-        placeholderTextColor={colors.content.secondary}
-        value={searchQuery}
-        onChangeText={onSearchChange}
-        onFocus={onFocus}
-        onBlur={onBlur}
-      />
-      {searchQuery !== '' && (
-        <Pressable
-          onPress={() => onSearchChange('')}
-          style={{ padding: spacing.xs }}
-        >
-          <Ionicons name="close-circle" size={18} color={colors.text.muted} />
-        </Pressable>
-      )}
-      {isSearchFocused && (
-        <Pressable onPress={onClear} style={{ marginLeft: spacing.sm }}>
-          <Text
-            style={{
-              fontSize: fontSize.xl,
-              color: colors.button.primary,
-              fontFamily: fontFamily.bodyMedium,
-            }}
+      >
+        <Ionicons name="search" size={18} color={colors.content.secondary} />
+        <TextInput
+          ref={searchInputRef}
+          style={{
+            flex: 1,
+            fontSize: fontSize.md,
+            color: colors.content.body,
+            marginLeft: spacing.sm,
+          }}
+          placeholder={t('recipes.searchPlaceholder')}
+          placeholderTextColor={colors.content.secondary}
+          value={searchQuery}
+          onChangeText={onSearchChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
+        />
+        {searchQuery !== '' && (
+          <Pressable
+            onPress={() => onSearchChange('')}
+            style={{ padding: spacing.xs }}
           >
-            {t('common.cancel')}
-          </Text>
-        </Pressable>
-      )}
+            <Ionicons name="close-circle" size={18} color={colors.text.muted} />
+          </Pressable>
+        )}
+        {isSearchFocused && (
+          <Pressable onPress={onClear} style={{ marginLeft: spacing.sm }}>
+            <Text
+              style={{
+                fontSize: fontSize.xl,
+                color: colors.button.primary,
+                fontFamily: fontFamily.bodyMedium,
+              }}
+            >
+              {t('common.cancel')}
+            </Text>
+          </Pressable>
+        )}
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
 interface FilterChipsProps {
   dietFilter: DietLabel | null;
@@ -106,8 +110,25 @@ interface FilterChipsProps {
   t: TFunction;
 }
 
-const DIET_CHIPS: { diet: DietLabel; dotColor: string; activeColor: string }[] =
-  [
+export const FilterChips = ({
+  dietFilter,
+  showFavoritesOnly,
+  libraryScope,
+  sortBy,
+  sortOptions,
+  onDietChange,
+  onFavoritesToggle,
+  onLibraryScopeChange,
+  onSortPress,
+  t,
+}: FilterChipsProps) => {
+  const { colors } = useTheme();
+
+  const dietChips: {
+    diet: DietLabel;
+    dotColor: string;
+    activeColor: string;
+  }[] = [
     {
       diet: 'veggie',
       dotColor: colors.ai.primary,
@@ -125,126 +146,82 @@ const DIET_CHIPS: { diet: DietLabel; dotColor: string; activeColor: string }[] =
     },
   ];
 
-export const FilterChips = ({
-  dietFilter,
-  showFavoritesOnly,
-  libraryScope,
-  sortBy,
-  sortOptions,
-  onDietChange,
-  onFavoritesToggle,
-  onLibraryScopeChange,
-  onSortPress,
-  t,
-}: FilterChipsProps) => (
-  <View style={{ paddingVertical: spacing.sm }}>
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{ paddingHorizontal: spacing.xl, gap: spacing.sm }}
-    >
-      {/* Library scope toggle */}
-      <View
-        style={{
-          flexDirection: 'row',
-          borderRadius: borderRadius.sm,
-          borderWidth: 1,
-          borderColor: colors.chip.border,
-          overflow: 'hidden',
+  return (
+    <View style={{ paddingVertical: spacing.sm }}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: spacing.xl,
+          gap: spacing.sm,
         }}
       >
-        <Pressable
-          onPress={() => {
-            hapticLight();
-            onLibraryScopeChange('all');
-          }}
+        {/* Library scope toggle */}
+        <View
           style={{
-            paddingHorizontal: spacing.md,
-            paddingVertical: spacing.xs,
-            backgroundColor:
-              libraryScope === 'all'
-                ? colors.button.primary
-                : colors.glass.dark,
+            flexDirection: 'row',
+            borderRadius: borderRadius.sm,
+            borderWidth: 1,
+            borderColor: colors.chip.border,
+            overflow: 'hidden',
           }}
         >
-          <Text
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              onLibraryScopeChange('all');
+            }}
             style={{
-              fontSize: fontSize.md,
-              fontFamily: fontFamily.bodySemibold,
-              color:
-                libraryScope === 'all' ? colors.white : colors.content.body,
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.xs,
+              backgroundColor:
+                libraryScope === 'all'
+                  ? colors.button.primary
+                  : colors.glass.dark,
             }}
           >
-            {t('recipes.scopeAll')}
-          </Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            hapticLight();
-            onLibraryScopeChange('mine');
-          }}
-          style={{
-            paddingHorizontal: spacing.md,
-            paddingVertical: spacing.xs,
-            backgroundColor:
-              libraryScope === 'mine'
-                ? colors.button.primary
-                : colors.glass.dark,
-          }}
-        >
-          <Text
+            <Text
+              style={{
+                fontSize: fontSize.md,
+                fontFamily: fontFamily.bodySemibold,
+                color:
+                  libraryScope === 'all' ? colors.white : colors.content.body,
+              }}
+            >
+              {t('recipes.scopeAll')}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              onLibraryScopeChange('mine');
+            }}
             style={{
-              fontSize: fontSize.md,
-              fontFamily: fontFamily.bodySemibold,
-              color:
-                libraryScope === 'mine' ? colors.white : colors.content.body,
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.xs,
+              backgroundColor:
+                libraryScope === 'mine'
+                  ? colors.button.primary
+                  : colors.glass.dark,
             }}
           >
-            {t('recipes.scopeMine')}
-          </Text>
-        </Pressable>
-      </View>
-      {/* All chip */}
-      <AnimatedPressable
-        onPress={() => {
-          hapticLight();
-          onDietChange(null);
-        }}
-        hoverScale={1.05}
-        pressScale={0.95}
-        style={{
-          paddingHorizontal: spacing.md,
-          paddingVertical: spacing.xs,
-          borderRadius: borderRadius.sm,
-          backgroundColor:
-            !dietFilter && !showFavoritesOnly
-              ? colors.content.body
-              : colors.chip.bg,
-          borderWidth: !dietFilter && !showFavoritesOnly ? 0 : 1,
-          borderColor: colors.chip.border,
-        }}
-      >
-        <Text
-          style={{
-            fontSize: fontSize.md,
-            fontFamily: fontFamily.bodySemibold,
-            color:
-              !dietFilter && !showFavoritesOnly
-                ? colors.white
-                : colors.content.body,
-          }}
-        >
-          {t('labels.diet.all')}
-        </Text>
-      </AnimatedPressable>
-
-      {/* Diet chips */}
-      {DIET_CHIPS.map(({ diet, dotColor, activeColor }) => (
+            <Text
+              style={{
+                fontSize: fontSize.md,
+                fontFamily: fontFamily.bodySemibold,
+                color:
+                  libraryScope === 'mine' ? colors.white : colors.content.body,
+              }}
+            >
+              {t('recipes.scopeMine')}
+            </Text>
+          </Pressable>
+        </View>
+        {/* All chip */}
         <AnimatedPressable
-          key={diet}
           onPress={() => {
             hapticLight();
-            onDietChange(dietFilter === diet ? null : diet);
+            onDietChange(null);
           }}
           hoverScale={1.05}
           pressScale={0.95}
@@ -252,103 +229,147 @@ export const FilterChips = ({
             paddingHorizontal: spacing.md,
             paddingVertical: spacing.xs,
             borderRadius: borderRadius.sm,
-            backgroundColor: dietFilter === diet ? activeColor : colors.chip.bg,
-            borderWidth: dietFilter === diet ? 0 : 1,
+            backgroundColor:
+              !dietFilter && !showFavoritesOnly
+                ? colors.content.body
+                : colors.chip.bg,
+            borderWidth: !dietFilter && !showFavoritesOnly ? 0 : 1,
+            borderColor: colors.chip.border,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: fontSize.md,
+              fontFamily: fontFamily.bodySemibold,
+              color:
+                !dietFilter && !showFavoritesOnly
+                  ? colors.white
+                  : colors.content.body,
+            }}
+          >
+            {t('labels.diet.all')}
+          </Text>
+        </AnimatedPressable>
+
+        {/* Diet chips */}
+        {dietChips.map(({ diet, dotColor, activeColor }) => (
+          <AnimatedPressable
+            key={diet}
+            onPress={() => {
+              hapticLight();
+              onDietChange(dietFilter === diet ? null : diet);
+            }}
+            hoverScale={1.05}
+            pressScale={0.95}
+            style={{
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.xs,
+              borderRadius: borderRadius.sm,
+              backgroundColor:
+                dietFilter === diet ? activeColor : colors.chip.bg,
+              borderWidth: dietFilter === diet ? 0 : 1,
+              borderColor: colors.chip.border,
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: spacing.xs,
+            }}
+          >
+            <View
+              style={{
+                width: dotSize.md,
+                height: dotSize.md,
+                borderRadius: dotSize.md / 2,
+                backgroundColor: dietFilter === diet ? colors.white : dotColor,
+              }}
+            />
+            <Text
+              style={{
+                fontSize: fontSize.md,
+                fontFamily: fontFamily.bodySemibold,
+                color: dietFilter === diet ? colors.white : colors.content.body,
+              }}
+            >
+              {t(`labels.diet.${diet}`)}
+            </Text>
+          </AnimatedPressable>
+        ))}
+
+        {/* Favorites chip */}
+        <AnimatedPressable
+          onPress={() => {
+            hapticLight();
+            onFavoritesToggle();
+          }}
+          hoverScale={1.05}
+          pressScale={0.95}
+          style={{
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+            backgroundColor: showFavoritesOnly
+              ? colors.chip.favoriteActive
+              : colors.chip.bg,
+            borderWidth: showFavoritesOnly ? 0 : 1,
             borderColor: colors.chip.border,
             flexDirection: 'row',
             alignItems: 'center',
             gap: spacing.xs,
           }}
         >
-          <View
-            style={{
-              width: dotSize.md,
-              height: dotSize.md,
-              borderRadius: dotSize.md / 2,
-              backgroundColor: dietFilter === diet ? colors.white : dotColor,
-            }}
+          <Ionicons
+            name={showFavoritesOnly ? 'heart' : 'heart-outline'}
+            size={15}
+            color={
+              showFavoritesOnly ? colors.white : colors.chip.favoriteActive
+            }
           />
           <Text
             style={{
               fontSize: fontSize.md,
               fontFamily: fontFamily.bodySemibold,
-              color: dietFilter === diet ? colors.white : colors.content.body,
+              color: showFavoritesOnly ? colors.white : colors.content.body,
             }}
           >
-            {t(`labels.diet.${diet}`)}
+            {t('recipes.favorites')}
           </Text>
         </AnimatedPressable>
-      ))}
 
-      {/* Favorites chip */}
-      <AnimatedPressable
-        onPress={() => {
-          hapticLight();
-          onFavoritesToggle();
-        }}
-        hoverScale={1.05}
-        pressScale={0.95}
-        style={{
-          paddingHorizontal: spacing.md,
-          paddingVertical: spacing.xs,
-          borderRadius: borderRadius.sm,
-          backgroundColor: showFavoritesOnly
-            ? colors.chip.favoriteActive
-            : colors.chip.bg,
-          borderWidth: showFavoritesOnly ? 0 : 1,
-          borderColor: colors.chip.border,
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: spacing.xs,
-        }}
-      >
-        <Ionicons
-          name={showFavoritesOnly ? 'heart' : 'heart-outline'}
-          size={15}
-          color={showFavoritesOnly ? colors.white : colors.chip.favoriteActive}
-        />
-        <Text
+        {/* Sort chip */}
+        <AnimatedPressable
+          onPress={() => {
+            hapticLight();
+            onSortPress();
+          }}
+          hoverScale={1.05}
+          pressScale={0.95}
           style={{
-            fontSize: fontSize.md,
-            fontFamily: fontFamily.bodySemibold,
-            color: showFavoritesOnly ? colors.white : colors.content.body,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.chip.bg,
+            borderWidth: 1,
+            borderColor: colors.chip.border,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: spacing.xs,
           }}
         >
-          {t('recipes.favorites')}
-        </Text>
-      </AnimatedPressable>
-
-      {/* Sort chip */}
-      <AnimatedPressable
-        onPress={() => {
-          hapticLight();
-          onSortPress();
-        }}
-        hoverScale={1.05}
-        pressScale={0.95}
-        style={{
-          paddingHorizontal: spacing.md,
-          paddingVertical: spacing.xs,
-          borderRadius: borderRadius.sm,
-          backgroundColor: colors.chip.bg,
-          borderWidth: 1,
-          borderColor: colors.chip.border,
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: spacing.xs,
-        }}
-      >
-        <Ionicons name="funnel-outline" size={13} color={colors.content.body} />
-        <Text
-          style={{
-            fontSize: fontSize.md,
-            fontFamily: fontFamily.bodySemibold,
-            color: colors.content.body,
-          }}
-        >
-          {sortOptions.find((o) => o.value === sortBy)?.label}
-        </Text>
-      </AnimatedPressable>
-    </ScrollView>
-  </View>
-);
+          <Ionicons
+            name="funnel-outline"
+            size={13}
+            color={colors.content.body}
+          />
+          <Text
+            style={{
+              fontSize: fontSize.md,
+              fontFamily: fontFamily.bodySemibold,
+              color: colors.content.body,
+            }}
+          >
+            {sortOptions.find((o) => o.value === sortBy)?.label}
+          </Text>
+        </AnimatedPressable>
+      </ScrollView>
+    </View>
+  );
+};


### PR DESCRIPTION
## Summary

Migrate 4 remaining files from static `colors` import to runtime `useTheme()` hook, completing the migration started in PR #286.

## Changes

- **CollapsedDayRow.tsx** — add `useTheme()`, move 4 color properties to inline style overrides, remove static `colors` import
- **RecipeFilters.tsx** — add `useTheme()` to both SearchBar and FilterChips components, move module-level `DIET_CHIPS` constant inside FilterChips as local `dietChips`, remove static `colors` import
- **sign-in.tsx** — add `useTheme()`, remove static `colors` import (all styles already inline)
- **ScreenTitle.tsx** — add `useTheme()`, move 4 color properties (heading, text.primary, shadow.text, content.subtitle, text.secondary) to inline style overrides, remove static `colors` import

## Remaining gaps (unchanged)

- **ErrorBoundary.tsx** — class component, cannot use hooks (accepted)
- **styles.ts** — theme internals, uses `colors` legitimately

## Testing

- 0 TypeScript errors
- 555/555 tests passing
