### PR TITLE
refactor: extract IconCircle component from 20 circular icon instances

### DIFF
--- a/mobile/app/add-recipe.tsx
+++ b/mobile/app/add-recipe.tsx
@@ -13,6 +13,7 @@ import {
   EnhancingOverlay,
   FormField,
   GradientBackground,
+  IconCircle,
   PrimaryButton,
 } from '@/components';
 import { ManualRecipeForm } from '@/components/add-recipe/ManualRecipeForm';
@@ -29,7 +30,6 @@ import {
   borderRadius,
   fontSize,
   fontWeight,
-  iconContainer,
   layout,
   letterSpacing,
   lineHeight,
@@ -208,19 +208,14 @@ export default function AddRecipeScreen() {
               <View
                 style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}
               >
-                <View
-                  style={{
-                    width: iconContainer.md,
-                    height: iconContainer.md,
-                    borderRadius: iconContainer.md / 2,
-                    backgroundColor:
-                      aiEnabled && enhanceWithAI
-                        ? colors.ai.light
-                        : colors.glass.light,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    marginRight: spacing.md,
-                  }}
+                <IconCircle
+                  size="md"
+                  bg={
+                    aiEnabled && enhanceWithAI
+                      ? colors.ai.light
+                      : colors.glass.light
+                  }
+                  style={{ marginRight: spacing.md }}
                 >
                   <Ionicons
                     name="sparkles"
@@ -231,7 +226,7 @@ export default function AddRecipeScreen() {
                         : colors.gray[500]
                     }
                   />
-                </View>
+                </IconCircle>
                 <View style={{ flex: 1 }}>
                   <Text
                     style={{

--- a/mobile/components/EmptyState.tsx
+++ b/mobile/components/EmptyState.tsx
@@ -1,10 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import type { ComponentProps } from 'react';
 import { Pressable, Text, View, type ViewStyle } from 'react-native';
+import { IconCircle } from '@/components';
 import {
   borderRadius,
   fontSize,
-  iconContainer,
   letterSpacing,
   lineHeight,
   shadows,
@@ -47,19 +47,13 @@ const EmptyState = ({
       ]}
     >
       {icon && (
-        <View
-          style={{
-            width: iconContainer['2xl'],
-            height: iconContainer['2xl'],
-            borderRadius: iconContainer['2xl'] / 2,
-            backgroundColor: colors.glass.card,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginBottom: spacing.xl,
-          }}
+        <IconCircle
+          size="2xl"
+          bg={colors.glass.card}
+          style={{ marginBottom: spacing.xl }}
         >
           <Ionicons name={icon} size={36} color={colors.text.inverse} />
-        </View>
+        </IconCircle>
       )}
       <Text
         style={{

--- a/mobile/components/EnhancementReviewModal.tsx
+++ b/mobile/components/EnhancementReviewModal.tsx
@@ -7,12 +7,11 @@ import {
   Text,
   View,
 } from 'react-native';
+import { IconCircle } from '@/components';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
-  iconContainer,
   iconSize,
   letterSpacing,
   lineHeight,
@@ -62,15 +61,17 @@ export const EnhancementReviewModal = ({
         <View style={[styles.card, { backgroundColor: colors.white }]}>
           {/* Header */}
           <View style={styles.header}>
-            <View
-              style={[styles.iconCircle, { backgroundColor: colors.ai.light }]}
+            <IconCircle
+              size="lg"
+              bg={colors.ai.light}
+              style={{ marginRight: spacing.md }}
             >
               <Ionicons
                 name="sparkles"
                 size={iconSize.xl}
                 color={colors.ai.primary}
               />
-            </View>
+            </IconCircle>
             <View style={styles.headerText}>
               <Text
                 style={[styles.headerLabel, { color: colors.text.inverse }]}
@@ -196,12 +197,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: spacing.lg,
-  },
-  iconCircle: {
-    ...circleStyle(iconContainer.lg),
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: spacing.md,
   },
   headerText: {
     flex: 1,

--- a/mobile/components/IconCircle.tsx
+++ b/mobile/components/IconCircle.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { View, type ViewStyle } from 'react-native';
+import {
+  circleStyle,
+  type IconContainerSize,
+  iconContainer,
+} from '@/lib/theme';
+
+interface IconCircleProps {
+  size: IconContainerSize | number;
+  bg: string;
+  style?: ViewStyle;
+  children: ReactNode;
+}
+
+export const IconCircle = ({ size, bg, style, children }: IconCircleProps) => {
+  const dimension = typeof size === 'number' ? size : iconContainer[size];
+
+  return (
+    <View
+      style={[
+        circleStyle(dimension),
+        { backgroundColor: bg, alignItems: 'center', justifyContent: 'center' },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+};

--- a/mobile/components/SectionHeader.tsx
+++ b/mobile/components/SectionHeader.tsx
@@ -1,13 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
-import {
-  circleStyle,
-  fontSize,
-  fontWeight,
-  iconContainer,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { IconCircle } from '@/components';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface SectionHeaderProps {
   icon: keyof typeof Ionicons.glyphMap;
@@ -39,17 +33,9 @@ export const SectionHeader = ({
         marginBottom: spacing.md,
       }}
     >
-      <View
-        style={{
-          ...circleStyle(iconContainer.md),
-          backgroundColor: bgColor,
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginRight: spacing.md,
-        }}
-      >
+      <IconCircle size="md" bg={bgColor} style={{ marginRight: spacing.md }}>
         <Ionicons name={icon} size={20} color={iconColor} />
-      </View>
+      </IconCircle>
       <View style={{ flex: 1 }}>
         <Text
           style={{

--- a/mobile/components/household-settings/CollapsibleSection.tsx
+++ b/mobile/components/household-settings/CollapsibleSection.tsx
@@ -1,14 +1,8 @@
 import { Ionicons } from '@expo/vector-icons';
 import { type ReactNode, useRef } from 'react';
 import { Animated, LayoutAnimation, Pressable, Text, View } from 'react-native';
-import {
-  circleStyle,
-  fontSize,
-  fontWeight,
-  iconContainer,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { IconCircle } from '@/components';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface CollapsibleSectionProps {
   icon: keyof typeof Ionicons.glyphMap;
@@ -65,17 +59,13 @@ export const CollapsibleSection = ({
           opacity: pressed ? 0.7 : 1,
         })}
       >
-        <View
-          style={{
-            ...circleStyle(iconContainer.md),
-            backgroundColor: colors.glass.faint,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: spacing.md,
-          }}
+        <IconCircle
+          size="md"
+          bg={colors.glass.faint}
+          style={{ marginRight: spacing.md }}
         >
           <Ionicons name={icon} size={20} color={iconColor} />
-        </View>
+        </IconCircle>
         <View style={{ flex: 1 }}>
           <Text
             style={{

--- a/mobile/components/household-settings/NoteSuggestionsSection.tsx
+++ b/mobile/components/household-settings/NoteSuggestionsSection.tsx
@@ -1,10 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useMemo, useState } from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
+import { IconCircle } from '@/components';
 import { useTranslation } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   dotSize,
   fontSize,
   fontWeight,
@@ -287,21 +287,17 @@ const EmptyState = () => {
         ...shadows.sm,
       }}
     >
-      <View
-        style={{
-          ...circleStyle(48),
-          backgroundColor: colors.bgDark,
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginBottom: spacing.sm,
-        }}
+      <IconCircle
+        size={48}
+        bg={colors.bgDark}
+        style={{ marginBottom: spacing.sm }}
       >
         <Ionicons
           name="document-text-outline"
           size={24}
           color={colors.content.body}
         />
-      </View>
+      </IconCircle>
       <Text
         style={{
           fontSize: fontSize.md,

--- a/mobile/components/index.ts
+++ b/mobile/components/index.ts
@@ -17,6 +17,7 @@ export { FullScreenLoading } from './FullScreenLoading';
 export { GradientBackground } from './GradientBackground';
 export { GroceryItemRow } from './GroceryItemRow';
 export { GroceryListView } from './GroceryListView';
+export { IconCircle } from './IconCircle';
 export { DayColumn, MealCell } from './MealGrid';
 export { PrimaryButton } from './PrimaryButton';
 export { RadioGroup } from './RadioGroup';

--- a/mobile/components/meal-plan/EmptyMealSlot.tsx
+++ b/mobile/components/meal-plan/EmptyMealSlot.tsx
@@ -1,15 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import type React from 'react';
 import { Text, View } from 'react-native';
-import { AnimatedPressable } from '@/components';
+import { AnimatedPressable, IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  circleStyle,
-  fontSize,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
 import type { MealType } from '@/lib/types';
 
 interface EmptyMealSlotProps {
@@ -47,17 +41,13 @@ export const EmptyMealSlot = ({
       <View
         style={{ flexDirection: 'row', alignItems: 'center', minWidth: 80 }}
       >
-        <View
-          style={{
-            ...circleStyle(26),
-            backgroundColor: colors.surface.active,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: spacing.sm,
-          }}
+        <IconCircle
+          size={26}
+          bg={colors.surface.active}
+          style={{ marginRight: spacing.sm }}
         >
           <Ionicons name="add" size={16} color={colors.content.subtitle} />
-        </View>
+        </IconCircle>
         <Text
           style={{
             fontSize: fontSize.md,

--- a/mobile/components/recipe-detail/InstructionItem.tsx
+++ b/mobile/components/recipe-detail/InstructionItem.tsx
@@ -1,10 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
+import { IconCircle } from '@/components';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
-  iconContainer,
   letterSpacing,
   lineHeight,
   shadows,
@@ -132,12 +131,10 @@ export const InstructionItem = ({
         ...shadows.card,
       })}
     >
-      <View
+      <IconCircle
+        size="sm"
+        bg={isCompleted ? colors.success : colors.content.body}
         style={{
-          ...circleStyle(iconContainer.sm),
-          backgroundColor: isCompleted ? colors.success : colors.content.body,
-          alignItems: 'center',
-          justifyContent: 'center',
           marginRight: spacing.md,
           marginTop: 2,
         }}
@@ -155,7 +152,7 @@ export const InstructionItem = ({
             {displayNumber}
           </Text>
         )}
-      </View>
+      </IconCircle>
       <View style={{ flex: 1 }}>
         {hasTime && (
           <View

--- a/mobile/components/recipe-detail/RecipeEnhancedInfo.tsx
+++ b/mobile/components/recipe-detail/RecipeEnhancedInfo.tsx
@@ -1,11 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
+import { IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
-  iconContainer,
   lineHeight,
   shadows,
   spacing,
@@ -41,21 +40,17 @@ export const RecipeEnhancedInfo = ({
               marginBottom: spacing.md,
             }}
           >
-            <View
-              style={{
-                ...circleStyle(iconContainer.xs),
-                backgroundColor: colors.ai.iconBg,
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginRight: spacing.md,
-              }}
+            <IconCircle
+              size="xs"
+              bg={colors.ai.iconBg}
+              style={{ marginRight: spacing.md }}
             >
               <Ionicons
                 name="bulb-outline"
                 size={18}
                 color={colors.ai.primary}
               />
-            </View>
+            </IconCircle>
             <Text
               style={{
                 ...typography.displaySmall,
@@ -111,17 +106,13 @@ export const RecipeEnhancedInfo = ({
                 opacity: pressed ? 0.7 : 1,
               })}
             >
-              <View
-                style={{
-                  ...circleStyle(iconContainer.xs),
-                  backgroundColor: colors.ai.iconBg,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginRight: spacing.md,
-                }}
+              <IconCircle
+                size="xs"
+                bg={colors.ai.iconBg}
+                style={{ marginRight: spacing.md }}
               >
                 <Ionicons name="sparkles" size={18} color={colors.ai.primary} />
-              </View>
+              </IconCircle>
               <Text
                 style={{
                   ...typography.displaySmall,

--- a/mobile/components/recipe-detail/RecipeIngredientsList.tsx
+++ b/mobile/components/recipe-detail/RecipeIngredientsList.tsx
@@ -1,11 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
+import { IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
-  iconContainer,
   lineHeight,
   shadows,
   spacing,
@@ -32,17 +31,13 @@ export const RecipeIngredientsList = ({
           marginBottom: spacing.lg,
         }}
       >
-        <View
-          style={{
-            ...circleStyle(iconContainer.xs),
-            backgroundColor: colors.surface.active,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: spacing.md,
-          }}
+        <IconCircle
+          size="xs"
+          bg={colors.surface.active}
+          style={{ marginRight: spacing.md }}
         >
           <Ionicons name="list" size={18} color={colors.content.body} />
-        </View>
+        </IconCircle>
         <Text
           style={{
             ...typography.displaySmall,

--- a/mobile/components/recipe-detail/RecipeInstructions.tsx
+++ b/mobile/components/recipe-detail/RecipeInstructions.tsx
@@ -1,11 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
+import { IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
-  iconContainer,
   lineHeight,
   spacing,
   typography,
@@ -37,17 +36,13 @@ export const RecipeInstructions = ({
           marginBottom: spacing.lg,
         }}
       >
-        <View
-          style={{
-            ...circleStyle(iconContainer.xs),
-            backgroundColor: colors.surface.active,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: spacing.md,
-          }}
+        <IconCircle
+          size="xs"
+          bg={colors.surface.active}
+          style={{ marginRight: spacing.md }}
         >
           <Ionicons name="book" size={18} color={colors.content.body} />
-        </View>
+        </IconCircle>
         <Text
           style={{
             ...typography.displaySmall,
@@ -138,14 +133,10 @@ export const RecipeInstructions = ({
                 opacity: isCompleted ? 0.7 : 1,
               })}
             >
-              <View
+              <IconCircle
+                size="sm"
+                bg={isCompleted ? colors.success : colors.primary}
                 style={{
-                  ...circleStyle(iconContainer.sm),
-                  backgroundColor: isCompleted
-                    ? colors.success
-                    : colors.primary,
-                  alignItems: 'center',
-                  justifyContent: 'center',
                   marginRight: spacing.md,
                   marginTop: 2,
                 }}
@@ -163,7 +154,7 @@ export const RecipeInstructions = ({
                     {index + 1}
                   </Text>
                 )}
-              </View>
+              </IconCircle>
               <Text
                 style={{
                   flex: 1,

--- a/mobile/components/recipe-detail/RecipeNotes.tsx
+++ b/mobile/components/recipe-detail/RecipeNotes.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { IconCircle } from '@/components';
 import { showAlert, showNotification } from '@/lib/alert';
 import { hapticLight } from '@/lib/haptics';
 import {
@@ -22,9 +23,7 @@ import {
 import type { TFunction } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
-  iconContainer,
   lineHeight,
   spacing,
   typography,
@@ -129,21 +128,17 @@ export const RecipeNotes = ({
           marginBottom: spacing.lg,
         }}
       >
-        <View
-          style={{
-            ...circleStyle(iconContainer.xs),
-            backgroundColor: colors.surface.active,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: spacing.md,
-          }}
+        <IconCircle
+          size="xs"
+          bg={colors.surface.active}
+          style={{ marginRight: spacing.md }}
         >
           <Ionicons
             name="chatbubble-ellipses-outline"
             size={18}
             color={colors.content.heading}
           />
-        </View>
+        </IconCircle>
         <Text
           style={{
             ...typography.displaySmall,

--- a/mobile/components/select-recipe/CopyMealTab.tsx
+++ b/mobile/components/select-recipe/CopyMealTab.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, ScrollView, Text, View } from 'react-native';
+import { IconCircle } from '@/components';
 import { EmptyState } from '@/components/EmptyState';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
 import {
@@ -45,17 +46,13 @@ export const CopyMealTab = ({ state }: CopyMealTabProps) => {
     >
       {/* Header with sage accent */}
       <View style={{ alignItems: 'center', marginBottom: spacing.lg }}>
-        <View
-          style={{
-            ...circleStyle(iconContainer.lg),
-            backgroundColor: colors.ai.light,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginBottom: spacing.sm,
-          }}
+        <IconCircle
+          size="lg"
+          bg={colors.ai.light}
+          style={{ marginBottom: spacing.sm }}
         >
           <Ionicons name="copy" size={24} color={colors.ai.primary} />
-        </View>
+        </IconCircle>
         <Text
           style={{
             fontSize: fontSize['2xl'],
@@ -185,22 +182,13 @@ export const CopyMealTab = ({ state }: CopyMealTabProps) => {
                 {MEAL_TYPE_LABELS[meal.mealType as MealType] || meal.mealType}
               </Text>
             </View>
-            <View
-              style={{
-                width: iconContainer.md,
-                height: iconContainer.md,
-                borderRadius: iconContainer.md / 2,
-                backgroundColor: colors.glass.light,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
+            <IconCircle size="md" bg={colors.glass.light}>
               <Ionicons
                 name="copy-outline"
                 size={18}
                 color={colors.text.inverse}
               />
-            </View>
+            </IconCircle>
           </Pressable>
         ))
       )}

--- a/mobile/components/select-recipe/QuickMealTab.tsx
+++ b/mobile/components/select-recipe/QuickMealTab.tsx
@@ -1,12 +1,12 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, TextInput, View } from 'react-native';
+import { IconCircle } from '@/components';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
 import {
   accentUnderlineStyle,
   borderRadius,
   fontSize,
   fontWeight,
-  iconContainer,
   letterSpacing,
   spacing,
   useTheme,
@@ -40,23 +40,17 @@ export const QuickMealTab = ({ state }: QuickMealTabProps) => {
         }}
       >
         <View style={{ alignItems: 'center', marginBottom: spacing.xl }}>
-          <View
-            style={{
-              width: iconContainer.xl,
-              height: iconContainer.xl,
-              borderRadius: iconContainer.xl / 2,
-              backgroundColor: colors.ai.light,
-              alignItems: 'center',
-              justifyContent: 'center',
-              marginBottom: spacing.md,
-            }}
+          <IconCircle
+            size="xl"
+            bg={colors.ai.light}
+            style={{ marginBottom: spacing.md }}
           >
             <Ionicons
               name="create-outline"
               size={28}
               color={colors.ai.primary}
             />
-          </View>
+          </IconCircle>
           <Text
             style={{
               fontSize: fontSize['3xl'],

--- a/mobile/components/select-recipe/RandomTab.tsx
+++ b/mobile/components/select-recipe/RandomTab.tsx
@@ -1,16 +1,15 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Image, Pressable, ScrollView, Text, View } from 'react-native';
+import { IconCircle } from '@/components';
 import { EmptyState } from '@/components/EmptyState';
 import { PrimaryButton } from '@/components/PrimaryButton';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
 import {
   accentUnderlineStyle,
   borderRadius,
-  circleStyle,
   dotSize,
   fontSize,
   fontWeight,
-  iconContainer,
   layout,
   letterSpacing,
   lineHeight,
@@ -145,17 +144,13 @@ const RandomHeader = ({
 
   return (
     <View style={{ alignItems: 'center', marginBottom: spacing['2xl'] }}>
-      <View
-        style={{
-          ...circleStyle(iconContainer.xl),
-          backgroundColor: colors.ai.light,
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginBottom: spacing.md,
-        }}
+      <IconCircle
+        size="xl"
+        bg={colors.ai.light}
+        style={{ marginBottom: spacing.md }}
       >
         <Ionicons name="dice" size={32} color={colors.ai.primary} />
-      </View>
+      </IconCircle>
       <Text
         style={{
           fontSize: fontSize['3xl'],

--- a/mobile/components/settings/AccountSection.tsx
+++ b/mobile/components/settings/AccountSection.tsx
@@ -1,13 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator, Text, View } from 'react-native';
-import { AnimatedPressable, SectionHeader } from '@/components';
+import { AnimatedPressable, IconCircle, SectionHeader } from '@/components';
 import { useTranslation } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
-  iconContainer,
   settingsSubtitleStyle,
   settingsTitleStyle,
   shadows,
@@ -47,14 +45,10 @@ export const AccountSection = ({
         }}
       >
         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <View
-            style={{
-              ...circleStyle(iconContainer.lg),
-              backgroundColor: colors.bgDark,
-              alignItems: 'center',
-              justifyContent: 'center',
-              marginRight: spacing.md,
-            }}
+          <IconCircle
+            size="lg"
+            bg={colors.bgDark}
+            style={{ marginRight: spacing.md }}
           >
             <Text
               style={{
@@ -65,7 +59,7 @@ export const AccountSection = ({
             >
               {userEmail?.[0]?.toUpperCase() || '?'}
             </Text>
-          </View>
+          </IconCircle>
           <View style={{ flex: 1 }}>
             <Text style={settingsTitleStyle}>
               {displayName || userEmail?.split('@')[0] || 'User'}

--- a/mobile/components/settings/ItemsAtHomeSection.tsx
+++ b/mobile/components/settings/ItemsAtHomeSection.tsx
@@ -1,14 +1,13 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useMemo, useState } from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
+import { IconCircle } from '@/components';
 import { showNotification } from '@/lib/alert';
 import { useTranslation } from '@/lib/i18n';
 import {
   borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
-  iconContainer,
   shadows,
   spacing,
   useTheme,
@@ -302,17 +301,13 @@ const EmptyItemsState = () => {
         ...shadows.sm,
       }}
     >
-      <View
-        style={{
-          ...circleStyle(iconContainer.lg),
-          backgroundColor: colors.bgDark,
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginBottom: spacing.sm,
-        }}
+      <IconCircle
+        size="lg"
+        bg={colors.bgDark}
+        style={{ marginBottom: spacing.sm }}
       >
         <Ionicons name="basket-outline" size={24} color={colors.content.body} />
-      </View>
+      </IconCircle>
       <Text
         style={{
           fontSize: fontSize.md,

--- a/mobile/lib/theme.ts
+++ b/mobile/lib/theme.ts
@@ -5,6 +5,7 @@
 
 export type { ColorTokens } from './theme/colors';
 export { colors, lightColors } from './theme/colors';
+export type { IconContainerSize } from './theme/layout';
 export {
   animation,
   borderRadius,

--- a/mobile/lib/theme/layout.ts
+++ b/mobile/lib/theme/layout.ts
@@ -87,6 +87,8 @@ export const iconContainer = {
   '2xl': 80,
 } as const;
 
+export type IconContainerSize = keyof typeof iconContainer;
+
 // Helper: generates width, height, borderRadius for a circular container
 export const circleStyle = (size: number) =>
   ({ width: size, height: size, borderRadius: size / 2 }) as const;

--- a/mobile/test/setup.ts
+++ b/mobile/test/setup.ts
@@ -118,6 +118,10 @@ vi.mock('@/components', () => ({
     const { createElement } = require('react');
     return createElement('div', { 'data-testid': `section-${title}` }, title);
   },
+  IconCircle: ({ children }: any) => {
+    const { createElement } = require('react');
+    return createElement('div', { 'data-testid': 'icon-circle' }, children);
+  },
   RadioGroup: ({ value, onChange }: any) => {
     const { createElement } = require('react');
     return createElement('div', { 'data-testid': `radio-${value}` });


### PR DESCRIPTION
## Summary

Extract shared `<IconCircle>` component from 20 duplicated circular icon container patterns across 17 consumer files.

Non-interactive circular icon containers all repeated the same boilerplate: `circleStyle(size)` or manual `width/height/borderRadius`, plus `backgroundColor`, `alignItems: 'center'`, `justifyContent: 'center'`. IconCircle consolidates this into a single component.

## Component API

```tsx
<IconCircle size="md" bg={colors.bgDark} style={{ marginRight: spacing.md }}>
  <Ionicons name="settings" size={20} color={colors.text.inverse} />
</IconCircle>
```

Props:
- `size: IconContainerSize | number` - named size token (`'xs'`..'2xl'`) or raw pixel value
- `bg: string` - background color
- `style?: ViewStyle` - additional styles (margins, etc.)
- `children: ReactNode` - icon or text content

## Changes

**New:** `IconCircle.tsx` component, `IconContainerSize` type exported from `layout.ts`/`theme.ts`

**Migrated files (20 instances across 17 files):**
- SectionHeader, CollapsibleSection (md, themed bg)
- AccountSection (lg, user initial text circle)
- EnhancementReviewModal (lg, AI icon)
- RecipeNotes, RecipeIngredientsList (xs, surface.active)
- RecipeInstructions, InstructionItem (xs+sm, conditional bg)
- RecipeEnhancedInfo (2x xs, AI icon bg)
- EmptyState (2xl, glass.card)
- EmptyMealSlot (26px literal, surface.active)
- CopyMealTab (lg header + md list indicator)
- NoteSuggestionsSection (48px literal, bgDark)
- RandomTab (xl, AI light)
- ItemsAtHomeSection (lg, bgDark)
- QuickMealTab (xl, AI light)
- add-recipe (md, conditional AI/glass bg)

**Not migrated:** 23 interactive circles where `Pressable` IS the circle - different pattern requiring `onPress`/pressed state handling.

## Stats

- 22 files changed, 154 insertions, 235 deletions (net -81 lines)
- All 555 tests passing
- TypeScript clean, Biome clean
