### PR TITLE
refactor: migrate borderRadius, shadows, circleStyle to useTheme()

### DIFF
--- a/mobile/app/(tabs)/admin.tsx
+++ b/mobile/app/(tabs)/admin.tsx
@@ -27,13 +27,10 @@ import {
 } from '@/lib/hooks/use-admin';
 import { useTranslation } from '@/lib/i18n';
 import {
-  borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
   iconContainer,
   layout,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -154,7 +151,7 @@ export default function AdminScreen() {
 
 const AdminHeader = ({ onBack }: { onBack: () => void }) => {
   const { t } = useTranslation();
-  const { colors } = useTheme();
+  const { colors, circleStyle, shadows } = useTheme();
 
   return (
     <View
@@ -194,7 +191,7 @@ const AdminHeader = ({ onBack }: { onBack: () => void }) => {
 
 const CurrentUserInfo = ({ email, role }: { email: string; role: string }) => {
   const { t } = useTranslation();
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
 
   return (
     <View
@@ -254,7 +251,7 @@ const CurrentUserInfo = ({ email, role }: { email: string; role: string }) => {
 
 const HouseholdsListHeader = ({ onCreateNew }: { onCreateNew: () => void }) => {
   const { t } = useTranslation();
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
 
   return (
     <View

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -14,11 +14,9 @@ import { ScreenTitle } from '@/components/ScreenTitle';
 import { hapticLight } from '@/lib/haptics';
 import { useHomeScreenData } from '@/lib/hooks/useHomeScreenData';
 import {
-  borderRadius,
   fontSize,
   layout,
   letterSpacing,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -147,7 +145,7 @@ const Header = ({
   t: TFn;
   onSettings: () => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
 
   return (
     <View
@@ -213,7 +211,7 @@ const NextMealCard = ({
   t: TFn;
   onPress: () => void;
 }) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   return (
     <View style={{ paddingHorizontal: spacing.lg, marginBottom: spacing.lg }}>

--- a/mobile/app/(tabs)/meal-plan.tsx
+++ b/mobile/app/(tabs)/meal-plan.tsx
@@ -19,18 +19,16 @@ import { WeekSelector } from '@/components/meal-plan/WeekSelector';
 import { ScreenTitle } from '@/components/ScreenTitle';
 import { useMealPlanActions } from '@/lib/hooks/useMealPlanActions';
 import {
-  borderRadius,
   iconContainer,
   iconSize,
   layout,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
 import { formatDateLocal, isPastDate } from '@/lib/utils/dateFormatter';
 
 export default function MealPlanScreen() {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const {
     t,
     language,

--- a/mobile/app/(tabs)/recipes.tsx
+++ b/mobile/app/(tabs)/recipes.tsx
@@ -21,13 +21,7 @@ import { hapticLight, hapticSelection } from '@/lib/haptics';
 import { useCurrentUser, useRecipes } from '@/lib/hooks';
 import { useTranslation } from '@/lib/i18n';
 import { useSettings } from '@/lib/settings-context';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  layout,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, layout, useTheme } from '@/lib/theme';
 import type { DietLabel, LibraryScope, MealLabel } from '@/lib/types';
 
 if (
@@ -38,7 +32,7 @@ if (
 }
 
 export default function RecipesScreen() {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const router = useRouter();
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -44,8 +44,10 @@ import {
 } from '@/lib/settings-context';
 import {
   ThemeProvider,
+  terminalBorderRadius,
   terminalColors,
   terminalFontFamily,
+  terminalShadows,
   useTheme,
 } from '@/lib/theme';
 import '../global.css';
@@ -174,10 +176,17 @@ export default function RootLayout() {
   const isTerminal = process.env.EXPO_PUBLIC_THEME === 'terminal';
   const themePalette = isTerminal ? terminalColors : undefined;
   const themeFonts = isTerminal ? terminalFontFamily : undefined;
+  const themeRadii = isTerminal ? terminalBorderRadius : undefined;
+  const themeShadows = isTerminal ? terminalShadows : undefined;
 
   return (
     <ErrorBoundary>
-      <ThemeProvider palette={themePalette} fonts={themeFonts}>
+      <ThemeProvider
+        palette={themePalette}
+        fonts={themeFonts}
+        radii={themeRadii}
+        shadowTokens={themeShadows}
+      >
         <AuthProvider>
           <QueryProvider>
             <SettingsProvider>

--- a/mobile/app/add-recipe.tsx
+++ b/mobile/app/add-recipe.tsx
@@ -28,13 +28,11 @@ import { showNotification } from '@/lib/alert';
 import { useAddRecipeActions } from '@/lib/hooks/useAddRecipeActions';
 import { useSettings } from '@/lib/settings-context';
 import {
-  borderRadius,
   fontSize,
   fontWeight,
   layout,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -51,7 +49,7 @@ const SUPPORTED_SITES = [
 ];
 
 export default function AddRecipeScreen() {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const actions = useAddRecipeActions();
   const { settings } = useSettings();
   const aiEnabled = settings.aiEnabled;

--- a/mobile/app/no-access.tsx
+++ b/mobile/app/no-access.tsx
@@ -11,16 +11,10 @@ import { showNotification } from '@/lib/alert';
 import { useCurrentUser } from '@/lib/hooks/use-admin';
 import { useAuth } from '@/lib/hooks/use-auth';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  lineHeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, lineHeight, spacing, useTheme } from '@/lib/theme';
 
 export default function NoAccessScreen() {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const router = useRouter();
   const { user, loading, signOut } = useAuth();
   const { t } = useTranslation();

--- a/mobile/app/recipe/[id].tsx
+++ b/mobile/app/recipe/[id].tsx
@@ -22,18 +22,12 @@ import { hapticLight, hapticSelection } from '@/lib/haptics';
 import { useMealPlan, useRecipe } from '@/lib/hooks';
 import { useRecipeActions } from '@/lib/hooks/useRecipeActions';
 import { useSettings } from '@/lib/settings-context';
-import {
-  circleStyle,
-  iconContainer,
-  layout,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { iconContainer, layout, spacing, useTheme } from '@/lib/theme';
 import type { MealType } from '@/lib/types';
 import { formatDateLocal, getWeekDatesArray } from '@/lib/utils/dateFormatter';
 
 export default function RecipeDetailScreen() {
-  const { colors } = useTheme();
+  const { colors, circleStyle } = useTheme();
   const HEADER_BUTTON_BG = colors.surface.overlayMedium;
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();

--- a/mobile/app/review-recipe.tsx
+++ b/mobile/app/review-recipe.tsx
@@ -25,7 +25,7 @@ import { ReviewVersionToggle } from '@/components/review-recipe/ReviewVersionTog
 import { showNotification } from '@/lib/alert';
 import { useCreateRecipe } from '@/lib/hooks/use-recipes';
 import { useTranslation } from '@/lib/i18n';
-import { borderRadius, fontSize, layout, spacing, useTheme } from '@/lib/theme';
+import { fontSize, layout, spacing, useTheme } from '@/lib/theme';
 import type {
   DietLabel,
   MealLabel,
@@ -36,7 +36,7 @@ import type {
 type VersionTab = 'original' | 'enhanced';
 
 export default function ReviewRecipeScreen() {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const router = useRouter();
   const params = useLocalSearchParams<{ preview: string }>();
   const { t } = useTranslation();

--- a/mobile/app/select-recipe.tsx
+++ b/mobile/app/select-recipe.tsx
@@ -10,14 +10,7 @@ import {
   type TabType,
   useSelectRecipeState,
 } from '@/lib/hooks/useSelectRecipeState';
-import {
-  borderRadius,
-  fontSize,
-  layout,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, layout, spacing, useTheme } from '@/lib/theme';
 
 const TAB_KEYS: TabType[] = ['library', 'random', 'quick', 'copy'];
 
@@ -109,7 +102,7 @@ interface TabBarProps {
 }
 
 const TabBar = ({ tabs, activeTab, onTabPress, labels }: TabBarProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
 
   return (
     <View style={{ paddingHorizontal: 20, paddingVertical: spacing.sm }}>

--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -9,10 +9,10 @@ import { FullScreenLoading, GradientBackground } from '../components';
 import { GoogleLogo } from '../components/GoogleLogo';
 import { useAuth } from '../lib/hooks/use-auth';
 import { useTranslation } from '../lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '../lib/theme';
+import { fontSize, spacing, useTheme } from '../lib/theme';
 
 export default function SignInScreen() {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const { user, loading, error, signIn, signOut } = useAuth();
   const { t } = useTranslation();
 

--- a/mobile/components/BottomSheetModal.tsx
+++ b/mobile/components/BottomSheetModal.tsx
@@ -3,13 +3,7 @@ import type { ReactNode } from 'react';
 import type { DimensionValue } from 'react-native';
 import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
 
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface BottomSheetModalProps {
   visible: boolean;
@@ -46,7 +40,7 @@ export const BottomSheetModal = ({
   scrollable = true,
   testID,
 }: BottomSheetModalProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const backgroundColor = backgroundColorProp ?? colors.white;
   const backdropContent = (
     <View

--- a/mobile/components/ChipPicker.tsx
+++ b/mobile/components/ChipPicker.tsx
@@ -1,6 +1,5 @@
 import { Pressable, Text, View } from 'react-native';
 import {
-  borderRadius,
   dotSize,
   fontSize,
   letterSpacing,
@@ -43,7 +42,7 @@ const ChipPicker = <T,>({
   t,
   variant = 'glass',
 }: ChipPickerProps<T>) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const isGlass = variant === 'glass';
   const inactiveBg = isGlass ? colors.glass.card : colors.gray[50];
   const inactiveBorder = isGlass ? colors.glass.border : colors.bgDark;

--- a/mobile/components/EmptyState.tsx
+++ b/mobile/components/EmptyState.tsx
@@ -3,11 +3,9 @@ import type { ComponentProps } from 'react';
 import { Pressable, Text, View, type ViewStyle } from 'react-native';
 import { IconCircle } from '@/components';
 import {
-  borderRadius,
   fontSize,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -34,7 +32,7 @@ const EmptyState = ({
   action,
   style,
 }: EmptyStateProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   return (
     <View
       style={[

--- a/mobile/components/EnhancementReviewModal.tsx
+++ b/mobile/components/EnhancementReviewModal.tsx
@@ -9,13 +9,11 @@ import {
 } from 'react-native';
 import { IconCircle } from '@/components';
 import {
-  borderRadius,
   fontSize,
   fontWeight,
   iconSize,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -47,7 +45,7 @@ export const EnhancementReviewModal = ({
   onReview,
   onRequestClose,
 }: EnhancementReviewModalProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   return (
     <Modal
       visible={visible}
@@ -58,7 +56,16 @@ export const EnhancementReviewModal = ({
       <View
         style={[styles.backdrop, { backgroundColor: colors.overlay.backdrop }]}
       >
-        <View style={[styles.card, { backgroundColor: colors.white }]}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.white,
+              borderRadius: borderRadius.lg,
+              ...shadows.xl,
+            },
+          ]}
+        >
           {/* Header */}
           <View style={styles.header}>
             <IconCircle
@@ -101,7 +108,10 @@ export const EnhancementReviewModal = ({
                     key={index}
                     style={[
                       styles.changeItem,
-                      { backgroundColor: colors.successBg },
+                      {
+                        backgroundColor: colors.successBg,
+                        borderRadius: borderRadius.sm,
+                      },
                     ]}
                   >
                     <Ionicons
@@ -138,6 +148,7 @@ export const EnhancementReviewModal = ({
                 {
                   backgroundColor: colors.glass.light,
                   borderColor: colors.gray[300],
+                  borderRadius: borderRadius.md,
                   opacity: pressed || isReviewPending ? 0.7 : 1,
                 },
               ]}
@@ -155,6 +166,8 @@ export const EnhancementReviewModal = ({
                 styles.approveButton,
                 {
                   backgroundColor: colors.ai.primary,
+                  borderRadius: borderRadius.md,
+                  ...shadows.sm,
                   opacity: pressed || isReviewPending ? 0.7 : 1,
                 },
               ]}
@@ -186,12 +199,10 @@ const styles = StyleSheet.create({
     padding: spacing['2xl'],
   },
   card: {
-    borderRadius: borderRadius.lg,
     padding: spacing['2xl'],
     width: '100%',
     maxWidth: 400,
     maxHeight: '80%',
-    ...shadows.xl,
   },
   header: {
     flexDirection: 'row',
@@ -224,7 +235,6 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     marginBottom: spacing.sm,
     padding: spacing.md,
-    borderRadius: borderRadius.sm,
   },
   changeIcon: {
     marginRight: spacing.sm,
@@ -246,7 +256,6 @@ const styles = StyleSheet.create({
   rejectButton: {
     flex: 1,
     paddingVertical: spacing.md,
-    borderRadius: borderRadius.md,
     alignItems: 'center',
     borderWidth: 1,
   },
@@ -257,9 +266,7 @@ const styles = StyleSheet.create({
   approveButton: {
     flex: 1,
     paddingVertical: spacing.md,
-    borderRadius: borderRadius.md,
     alignItems: 'center',
-    ...shadows.sm,
   },
   approveContent: {
     flexDirection: 'row',

--- a/mobile/components/EnhancingOverlay.tsx
+++ b/mobile/components/EnhancingOverlay.tsx
@@ -5,13 +5,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator, Modal, StyleSheet, Text, View } from 'react-native';
-import {
-  borderRadius,
-  fontSize,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface EnhancingOverlayProps {
   visible: boolean;
@@ -22,7 +16,7 @@ export const EnhancingOverlay = ({
   visible,
   message,
 }: EnhancingOverlayProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   return (
     <Modal
       visible={visible}
@@ -34,7 +28,16 @@ export const EnhancingOverlay = ({
       <View
         style={[styles.backdrop, { backgroundColor: colors.overlay.backdrop }]}
       >
-        <View style={[styles.card, { backgroundColor: colors.glass.heavy }]}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.glass.heavy,
+              borderRadius: borderRadius.lg,
+              ...shadows.cardRaised,
+            },
+          ]}
+        >
           <Ionicons name="sparkles" size={32} color={colors.ai.primary} />
           <ActivityIndicator
             size="large"
@@ -63,10 +66,8 @@ const styles = StyleSheet.create({
     padding: spacing.xl,
   },
   card: {
-    borderRadius: borderRadius.lg,
     padding: spacing['3xl'],
     alignItems: 'center',
-    ...shadows.cardRaised,
     maxWidth: 300,
     width: '100%',
   },

--- a/mobile/components/FilterChip.tsx
+++ b/mobile/components/FilterChip.tsx
@@ -1,12 +1,6 @@
 import type { ReactNode } from 'react';
 import { Pressable, Text, type TextStyle, type ViewStyle } from 'react-native';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface FilterChipProps {
   label: string;
@@ -50,7 +44,7 @@ const FilterChip = ({
   style,
   labelStyle,
 }: FilterChipProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const activeColor = activeColorProp ?? colors.content.body;
   const activeTextColor = activeTextColorProp ?? colors.white;
   const inactiveTextColor = inactiveTextColorProp ?? colors.content.body;

--- a/mobile/components/FloatingTabBar.tsx
+++ b/mobile/components/FloatingTabBar.tsx
@@ -10,7 +10,7 @@ import { usePathname, useRouter } from 'expo-router';
 import { Platform, Pressable, StyleSheet, View } from 'react-native';
 import { useAuth } from '@/lib/hooks/use-auth';
 import { useTranslation } from '@/lib/i18n';
-import { borderRadius, layout, shadows, spacing, useTheme } from '@/lib/theme';
+import { layout, spacing, useTheme } from '@/lib/theme';
 
 type TabDef = {
   route: string;
@@ -117,7 +117,7 @@ export const FloatingTabBar = () => {
   const pathname = usePathname();
   const router = useRouter();
   const { t } = useTranslation();
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
 
   // Hide on auth screens or when not logged in
   if (!user || HIDDEN_ON.includes(pathname)) return null;
@@ -141,6 +141,7 @@ export const FloatingTabBar = () => {
                 <View
                   style={[
                     styles.iconWrap,
+                    { borderRadius: borderRadius.sm },
                     active && {
                       backgroundColor: colors.tabBar.focusBg,
                     },
@@ -187,7 +188,6 @@ const styles = StyleSheet.create({
     maxWidth: layout.contentMaxWidth,
     width: '100%',
     borderRadius: layout.tabBar.borderRadius,
-    ...shadows.md,
   },
   bottomFill: {
     height: layout.tabBar.bottomOffset,
@@ -198,7 +198,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   iconWrap: {
-    borderRadius: borderRadius.sm,
     paddingHorizontal: 12,
     paddingVertical: spacing['xs-sm'],
   },

--- a/mobile/components/GroceryItemRow.tsx
+++ b/mobile/components/GroceryItemRow.tsx
@@ -6,14 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useState } from 'react';
 import { Platform, Pressable, Text, View, type ViewStyle } from 'react-native';
 import { hapticSelection } from '@/lib/haptics';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { GroceryItem } from '@/lib/types';
 
 interface GroceryItemRowProps {
@@ -63,7 +56,7 @@ export const GroceryItemRow = ({
   isActive,
   showReorder,
 }: GroceryItemRowProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   const [checked, setChecked] = useState(item.checked);
   const quantity = formatQuantity(item);
 

--- a/mobile/components/GroceryListView.tsx
+++ b/mobile/components/GroceryListView.tsx
@@ -12,7 +12,6 @@ import DraggableFlatList, {
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useTranslation } from '@/lib/i18n';
 import {
-  borderRadius,
   fontSize,
   fontWeight,
   layout,
@@ -36,7 +35,7 @@ export const GroceryListView = ({
   filterOutItems,
   onReorder,
 }: GroceryListViewProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const { t } = useTranslation();
   const [reorderMode, setReorderMode] = useState(false);
   const [orderedItems, setOrderedItems] = useState<GroceryItem[]>([]);

--- a/mobile/components/IconCircle.tsx
+++ b/mobile/components/IconCircle.tsx
@@ -1,10 +1,6 @@
 import type { ReactNode } from 'react';
 import { View, type ViewStyle } from 'react-native';
-import {
-  circleStyle,
-  type IconContainerSize,
-  iconContainer,
-} from '@/lib/theme';
+import { type IconContainerSize, iconContainer, useTheme } from '@/lib/theme';
 
 interface IconCircleProps {
   size: IconContainerSize | number;
@@ -14,6 +10,7 @@ interface IconCircleProps {
 }
 
 export const IconCircle = ({ size, bg, style, children }: IconCircleProps) => {
+  const { circleStyle } = useTheme();
   const dimension = typeof size === 'number' ? size : iconContainer[size];
 
   return (

--- a/mobile/components/MealGrid.tsx
+++ b/mobile/components/MealGrid.tsx
@@ -6,13 +6,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { MealType, Recipe } from '@/lib/types';
 import { formatDateLocal } from '@/lib/utils/dateFormatter';
 
@@ -47,7 +41,7 @@ export const MealCell = ({
   onPress,
   onLongPress,
 }: MealCellProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const { t } = useTranslation();
   const hasContent = recipe || customText;
   const displayText = recipe?.title || customText;
@@ -125,7 +119,7 @@ export const DayColumn = ({
   onMealPress,
   onMealLongPress,
 }: DayColumnProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
   const dayNumber = date.getDate();
   const isToday = new Date().toDateString() === date.toDateString();

--- a/mobile/components/PrimaryButton.tsx
+++ b/mobile/components/PrimaryButton.tsx
@@ -10,13 +10,7 @@ import { Ionicons } from '@expo/vector-icons';
 import type { ComponentProps } from 'react';
 import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { AnimatedPressable } from '@/components/AnimatedPressable';
-import {
-  borderRadius,
-  fontSize,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 type IconName = ComponentProps<typeof IoniconsType>['name'];
 
@@ -52,7 +46,7 @@ export function PrimaryButton({
   pressedColor,
   disabledColor: disabledColorProp,
 }: PrimaryButtonProps) {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   const color = colorProp ?? colors.button.primary;
   const disabledColor = disabledColorProp ?? colors.button.disabled;
   const isDisabled = disabled || isPending;
@@ -74,6 +68,8 @@ export function PrimaryButton({
         styles.button,
         {
           backgroundColor: pressed && pressedColor ? pressedColor : activeColor,
+          borderRadius: borderRadius.md,
+          ...shadows.md,
           opacity: pressed && !pressedColor ? 0.9 : 1,
         },
       ]}
@@ -111,8 +107,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingVertical: spacing.lg,
     paddingHorizontal: spacing.xl,
-    borderRadius: borderRadius.md,
-    ...shadows.md,
   },
   icon: {
     marginRight: spacing.sm,

--- a/mobile/components/RadioGroup.tsx
+++ b/mobile/components/RadioGroup.tsx
@@ -1,12 +1,5 @@
 import { Pressable, Text, View } from 'react-native';
-import {
-  borderRadius,
-  circleStyle,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface RadioOption<T extends string> {
   value: T;
@@ -27,7 +20,7 @@ export const RadioGroup = <T extends string>({
   onChange,
   disabled = false,
 }: RadioGroupProps<T>) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, circleStyle } = useTheme();
   return (
     <View style={{ gap: spacing.sm }}>
       {options.map((option) => {

--- a/mobile/components/RecipeCard.tsx
+++ b/mobile/components/RecipeCard.tsx
@@ -19,14 +19,11 @@ import { hapticLight } from '@/lib/haptics';
 import { useTranslation } from '@/lib/i18n';
 import { useSettings } from '@/lib/settings-context';
 import {
-  borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
   iconContainer,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -58,7 +55,7 @@ export const RecipeCard = ({
   cardSize,
   showFavorite = true,
 }: RecipeCardProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows, circleStyle } = useTheme();
   const { isFavorite, toggleFavorite } = useSettings();
   const { t } = useTranslation();
   const isRecipeFavorite = isFavorite(recipe.id);

--- a/mobile/components/StepperControl.tsx
+++ b/mobile/components/StepperControl.tsx
@@ -1,7 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import {
-  circleStyle,
   fontSize,
   fontWeight,
   iconContainer,
@@ -26,7 +25,7 @@ export const StepperControl = ({
   incrementDisabled = false,
   subtitle,
 }: StepperControlProps) => {
-  const { colors } = useTheme();
+  const { colors, circleStyle } = useTheme();
   return (
     <View
       style={{

--- a/mobile/components/SurfaceCard.tsx
+++ b/mobile/components/SurfaceCard.tsx
@@ -9,7 +9,7 @@
 import type React from 'react';
 import type { ViewStyle } from 'react-native';
 import { View } from 'react-native';
-import { borderRadius, shadows, spacing, useTheme } from '@/lib/theme';
+import { spacing, useTheme } from '@/lib/theme';
 
 interface SurfaceCardProps {
   children: React.ReactNode;
@@ -24,7 +24,7 @@ export const SurfaceCard = ({
   padding = spacing.lg,
   style,
 }: SurfaceCardProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
 
   return (
     <View

--- a/mobile/components/add-recipe/ManualRecipeForm.tsx
+++ b/mobile/components/add-recipe/ManualRecipeForm.tsx
@@ -12,12 +12,10 @@ import {
 import { FormField, GradientBackground, PrimaryButton } from '@/components';
 import type { useAddRecipeActions } from '@/lib/hooks/useAddRecipeActions';
 import {
-  borderRadius,
   fontSize,
   fontWeight,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -29,7 +27,7 @@ interface ManualRecipeFormProps {
 }
 
 export const ManualRecipeForm = ({ actions }: ManualRecipeFormProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const {
     t,
     isPending,
@@ -299,7 +297,7 @@ const NumericField = ({
   onChangeText,
   disabled,
 }: NumericFieldProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
 
   return (
     <FormField label={label} compact>

--- a/mobile/components/admin/AddMemberForm.tsx
+++ b/mobile/components/admin/AddMemberForm.tsx
@@ -8,14 +8,7 @@ import {
 } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface AddMemberFormProps {
   newMemberEmail: string;
@@ -36,7 +29,7 @@ export const AddMemberForm = ({
   onClose,
   isPending,
 }: AddMemberFormProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/admin/CreateHouseholdModal.tsx
+++ b/mobile/components/admin/CreateHouseholdModal.tsx
@@ -9,14 +9,7 @@ import {
 } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 interface CreateHouseholdModalProps {
   visible: boolean;
@@ -35,7 +28,7 @@ export const CreateHouseholdModal = ({
   onClose,
   isPending,
 }: CreateHouseholdModalProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/admin/HouseholdCard.tsx
+++ b/mobile/components/admin/HouseholdCard.tsx
@@ -1,13 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { Household } from '@/lib/types';
 
 interface HouseholdCardProps {
@@ -16,7 +9,7 @@ interface HouseholdCardProps {
 }
 
 export const HouseholdCard = ({ household, onPress }: HouseholdCardProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   return (
     <Pressable
       onPress={onPress}

--- a/mobile/components/admin/HouseholdDetailModal.tsx
+++ b/mobile/components/admin/HouseholdDetailModal.tsx
@@ -11,12 +11,9 @@ import {
 } from '@/lib/hooks/use-admin';
 import { useTranslation } from '@/lib/i18n';
 import {
-  borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
   iconContainer,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -156,7 +153,7 @@ const ModalHeader = ({
   household: Household;
   onClose: () => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, circleStyle, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -203,7 +200,7 @@ const ModalHeader = ({
 };
 
 const MembersListHeader = ({ onAddMember }: { onAddMember: () => void }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -259,7 +256,7 @@ const MemberCard = ({
   member: HouseholdMember;
   onRemove: () => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
   const roleColor =
     member.role === 'admin' ? colors.warning : colors.text.muted;

--- a/mobile/components/grocery/AddItemCard.tsx
+++ b/mobile/components/grocery/AddItemCard.tsx
@@ -1,13 +1,7 @@
 import { Text, TextInput, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface AddItemCardProps {
   newItemText: string;
@@ -20,7 +14,7 @@ export const AddItemCard = ({
   onChangeText,
   onSubmit,
 }: AddItemCardProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/grocery/ClearMenu.tsx
+++ b/mobile/components/grocery/ClearMenu.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface ClearMenuProps {
   onClearMealPlanItems: () => void;
@@ -15,7 +15,7 @@ export const ClearMenu = ({
   onClearManualItems,
   onClearAll,
 }: ClearMenuProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/grocery/StatsCard.tsx
+++ b/mobile/components/grocery/StatsCard.tsx
@@ -3,14 +3,7 @@ import { useRouter } from 'expo-router';
 import { Text, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import { ClearMenu } from './ClearMenu';
 
 interface ActionButtonsProps {
@@ -32,7 +25,7 @@ const ActionButtons = ({
   onToggleClearMenu,
   onClearChecked,
 }: ActionButtonsProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   return (
     <View style={{ flexDirection: 'row', gap: spacing['xs-sm'] }}>
       <AnimatedPressable
@@ -106,7 +99,7 @@ interface ProgressBarProps {
 }
 
 const ProgressBar = ({ itemsToBuy, checkedItemsToBuy }: ProgressBarProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   if (itemsToBuy <= 0) return null;
 
   return (
@@ -139,7 +132,7 @@ interface ItemsAtHomeIndicatorProps {
 const ItemsAtHomeIndicator = ({
   hiddenAtHomeCount,
 }: ItemsAtHomeIndicatorProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const router = useRouter();
   const { t } = useTranslation();
 
@@ -212,7 +205,7 @@ export const StatsCard = ({
   onClearManualItems,
   onClearAll,
 }: StatsCardProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/home/AddRecipeModal.tsx
+++ b/mobile/components/home/AddRecipeModal.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'expo-router';
 import { Pressable, Text, TextInput, View } from 'react-native';
 import { BottomSheetModal } from '@/components';
 import type { useHomeScreenData } from '@/lib/hooks/useHomeScreenData';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 type Data = ReturnType<typeof useHomeScreenData>;
 
@@ -24,7 +24,7 @@ export const AddRecipeModal = ({
   onImport,
   t,
 }: AddRecipeModalProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const router = useRouter();
 
   const handleSubmit = () => {

--- a/mobile/components/home/InspirationSection.tsx
+++ b/mobile/components/home/InspirationSection.tsx
@@ -7,7 +7,6 @@ import { AnimatedPressable } from '@/components';
 import { hapticLight } from '@/lib/haptics';
 import type { useHomeScreenData } from '@/lib/hooks/useHomeScreenData';
 import {
-  borderRadius,
   fontSize,
   fontWeight,
   letterSpacing,
@@ -61,7 +60,7 @@ const InspirationHeader = ({
   t: Data['t'];
   onShuffle: () => void;
 }) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   return (
     <View
@@ -123,7 +122,7 @@ const InspirationCard = ({
   t: Data['t'];
   onPress: () => void;
 }) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   return (
     <AnimatedPressable
@@ -201,7 +200,7 @@ const LabelBadge = ({
   label: string;
   borderColor: string;
 }) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   return (
     <View
@@ -234,7 +233,7 @@ const GetStartedFallback = ({
   t: Data['t'];
   onPress: () => void;
 }) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   return (
     <View style={{ paddingHorizontal: spacing.lg, marginBottom: spacing.lg }}>

--- a/mobile/components/home/StatsCards.tsx
+++ b/mobile/components/home/StatsCards.tsx
@@ -4,14 +4,7 @@ import { Text, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import type { useHomeScreenData } from '@/lib/hooks/useHomeScreenData';
 import { WEEKLY_TRACKABLE_MEALS } from '@/lib/hooks/useHomeScreenData';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, letterSpacing, spacing, useTheme } from '@/lib/theme';
 
 type Data = ReturnType<typeof useHomeScreenData>;
 
@@ -85,7 +78,7 @@ const StatCard = ({
   iconColor,
   onPress,
 }: StatCardProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
 
   return (
     <AnimatedPressable

--- a/mobile/components/household-settings/AiSection.tsx
+++ b/mobile/components/household-settings/AiSection.tsx
@@ -2,14 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, TextInput, View } from 'react-native';
 import { RadioGroup, StepperControl } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { HouseholdSettings, MincedMeatPreference } from '@/lib/types';
 import { EQUIPMENT_CATEGORIES } from './constants';
 
@@ -33,7 +26,7 @@ export const AiSection = ({
   onUpdateDietary,
   onToggleEquipment,
 }: AiSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   const meatPortions = Math.min(
@@ -256,7 +249,7 @@ const SelectedEquipment = ({
   canEdit: boolean;
   onToggle: (key: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   if (equipment.length === 0) return null;
@@ -331,7 +324,7 @@ const AvailableEquipment = ({
   canEdit: boolean;
   onToggle: (key: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/household-settings/DietarySection.tsx
+++ b/mobile/components/household-settings/DietarySection.tsx
@@ -1,14 +1,7 @@
 import { Text, View } from 'react-native';
 import { RadioGroup, ThemeToggle } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { DairyPreference, HouseholdSettings } from '@/lib/types';
 
 interface DietarySectionProps {
@@ -25,7 +18,7 @@ export const DietarySection = ({
   canEdit,
   onUpdateDietary,
 }: DietarySectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   const dairyOptions: {

--- a/mobile/components/household-settings/EquipmentSection.tsx
+++ b/mobile/components/household-settings/EquipmentSection.tsx
@@ -1,14 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import { EQUIPMENT_CATEGORIES } from './constants';
 
 interface EquipmentSectionProps {
@@ -26,7 +19,7 @@ const SelectedEquipment = ({
   canEdit: boolean;
   onToggle: (key: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   if (equipment.length === 0) return null;
@@ -101,7 +94,7 @@ const AvailableEquipment = ({
   canEdit: boolean;
   onToggle: (key: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/household-settings/GeneralSection.tsx
+++ b/mobile/components/household-settings/GeneralSection.tsx
@@ -9,12 +9,9 @@ import {
 import { StepperControl, ThemeToggle } from '@/components';
 import { useTranslation } from '@/lib/i18n';
 import {
-  borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
   iconContainer,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -49,7 +46,7 @@ export const GeneralSection = ({
   onUpdateServings,
   onUpdateIncludeBreakfast,
 }: GeneralSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows, circleStyle } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/household-settings/MembersSection.tsx
+++ b/mobile/components/household-settings/MembersSection.tsx
@@ -8,14 +8,7 @@ import {
 } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { HouseholdMember } from '@/lib/types';
 
 interface MembersSectionProps {
@@ -43,7 +36,7 @@ const MemberCard = ({
   canEdit: boolean;
   onRemove: () => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
   const roleColor =
     member.role === 'admin' ? colors.warning : colors.text.muted;
@@ -145,7 +138,7 @@ const AddMemberForm = ({
   | 'onAddMember'
   | 'isAddPending'
 >) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -272,7 +265,7 @@ export const MembersSection = ({
   onRemoveMember,
   isAddPending,
 }: MembersSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/household-settings/NoteSuggestionsSection.tsx
+++ b/mobile/components/household-settings/NoteSuggestionsSection.tsx
@@ -3,15 +3,7 @@ import { useMemo, useState } from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
 import { IconCircle } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  dotSize,
-  fontSize,
-  fontWeight,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { dotSize, fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 const DEFAULT_SUGGESTION_KEYS = [
   'office',
@@ -35,7 +27,7 @@ export const NoteSuggestionsSection = ({
   onAdd,
   onRemove,
 }: NoteSuggestionsSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
   const [newSuggestion, setNewSuggestion] = useState('');
 
@@ -132,7 +124,7 @@ const CurrentSuggestions = ({
   canEdit: boolean;
   onRemove: (item: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -209,7 +201,7 @@ const PresetSuggestions = ({
   items: string[];
   onAdd: (item: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -273,7 +265,7 @@ const PresetSuggestions = ({
 };
 
 const EmptyState = () => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/household-settings/SaveControls.tsx
+++ b/mobile/components/household-settings/SaveControls.tsx
@@ -2,10 +2,10 @@ import { Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
 import { BottomActionBar, PrimaryButton } from '@/components';
 import { useTranslation } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 export const ReadOnlyBanner = () => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/household-settings/ScreenHeader.tsx
+++ b/mobile/components/household-settings/ScreenHeader.tsx
@@ -2,14 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import { ScreenTitle } from '@/components/ScreenTitle';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  layout,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, layout, spacing, useTheme } from '@/lib/theme';
 
 interface ScreenHeaderProps {
   canEdit: boolean;
@@ -26,7 +19,7 @@ export const ScreenHeader = ({
   onSave,
   onBack,
 }: ScreenHeaderProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/meal-plan/CollapsedDayRow.tsx
+++ b/mobile/components/meal-plan/CollapsedDayRow.tsx
@@ -1,15 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  iconSize,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, iconSize, spacing, useTheme } from '@/lib/theme';
 import { toBcp47 } from '@/lib/utils/dateFormatter';
 
 interface CollapsedDayRowProps {
@@ -27,7 +19,7 @@ export const CollapsedDayRow = ({
   t,
   onExpand,
 }: CollapsedDayRowProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const bcp47 = toBcp47(language);
   const dayName = date.toLocaleDateString(bcp47, { weekday: 'short' });
   const monthDay = date.toLocaleDateString(bcp47, {
@@ -42,7 +34,14 @@ export const CollapsedDayRow = ({
   return (
     <Pressable
       onPress={onExpand}
-      style={[styles.container, { backgroundColor: colors.glass.card }]}
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.glass.card,
+          borderRadius: borderRadius.sm,
+          ...shadows.xs,
+        },
+      ]}
     >
       <View style={styles.left}>
         <Text style={[styles.dayName, { color: colors.content.body }]}>
@@ -71,11 +70,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    borderRadius: borderRadius.sm,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
     marginBottom: spacing.sm,
-    ...shadows.xs,
   },
   left: {
     flexDirection: 'row',

--- a/mobile/components/meal-plan/DayHeader.tsx
+++ b/mobile/components/meal-plan/DayHeader.tsx
@@ -1,14 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  dotSize,
-  fontSize,
-  iconSize,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { dotSize, fontSize, iconSize, spacing, useTheme } from '@/lib/theme';
 import { formatDayHeader } from '@/lib/utils/dateFormatter';
 
 interface DayHeaderProps {
@@ -44,7 +37,7 @@ export const DayHeader = ({
   onToggleTag,
   onCollapse,
 }: DayHeaderProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <>
       <Pressable
@@ -210,7 +203,7 @@ const NoteEditor = ({
   onCancel,
   onToggleTag,
 }: NoteEditorProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View style={{ marginBottom: spacing.md }}>
       <View

--- a/mobile/components/meal-plan/EmptyMealSlot.tsx
+++ b/mobile/components/meal-plan/EmptyMealSlot.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { Text, View } from 'react-native';
 import { AnimatedPressable, IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 import type { MealType } from '@/lib/types';
 
 interface EmptyMealSlotProps {
@@ -25,7 +25,7 @@ export const EmptyMealSlot = ({
   t,
   onPress,
 }: EmptyMealSlotProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View
       style={{
@@ -123,7 +123,7 @@ const SecondaryActionButton = ({
   icon,
   onPress,
 }: SecondaryActionButtonProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   return (
     <AnimatedPressable
       onPress={onPress}

--- a/mobile/components/meal-plan/ExtrasSection.tsx
+++ b/mobile/components/meal-plan/ExtrasSection.tsx
@@ -3,14 +3,7 @@ import { useRouter } from 'expo-router';
 import { Image, Pressable, Text, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  circleStyle,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import type { Recipe } from '@/lib/types';
 import { PLACEHOLDER_IMAGE } from './meal-plan-constants';
 
@@ -27,7 +20,7 @@ export const ExtrasSection = ({
   onAddExtra,
   onRemoveExtra,
 }: ExtrasSectionProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View
       style={{
@@ -147,7 +140,7 @@ interface ExtraRecipeRowProps {
 }
 
 const ExtraRecipeRow = ({ recipe, onRemove }: ExtraRecipeRowProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, circleStyle } = useTheme();
   const router = useRouter();
   const imageUrl =
     recipe.thumbnail_url || recipe.image_url || PLACEHOLDER_IMAGE;

--- a/mobile/components/meal-plan/FilledMealSlot.tsx
+++ b/mobile/components/meal-plan/FilledMealSlot.tsx
@@ -2,13 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Image, Pressable, Text, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
-import {
-  borderRadius,
-  circleStyle,
-  fontSize,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 import type { MealType, Recipe } from '@/lib/types';
 import { formatDateLocal } from '@/lib/utils/dateFormatter';
 import { PLACEHOLDER_IMAGE } from './meal-plan-constants';
@@ -41,7 +35,7 @@ export const FilledMealSlot = ({
   onRemove,
   onMealPress,
 }: FilledMealSlotProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, circleStyle } = useTheme();
   const router = useRouter();
   const title = recipe?.title || customText || '';
   const imageUrl =

--- a/mobile/components/meal-plan/GrocerySelectionModal.tsx
+++ b/mobile/components/meal-plan/GrocerySelectionModal.tsx
@@ -3,14 +3,7 @@ import { Pressable, ScrollView, Text, View } from 'react-native';
 import { BottomSheetModal, PrimaryButton } from '@/components';
 import { hapticSuccess } from '@/lib/haptics';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  circleStyle,
-  fontSize,
-  iconContainer,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, iconContainer, spacing, useTheme } from '@/lib/theme';
 import type { MealType, Recipe } from '@/lib/types';
 import {
   formatDateLocal,
@@ -172,7 +165,7 @@ const GroceryWeekSelector = ({
   onPreviousWeek,
   onNextWeek,
 }: GroceryWeekSelectorProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, circleStyle } = useTheme();
   return (
     <View
       style={{
@@ -255,7 +248,7 @@ const GroceryMealItem = ({
   onToggle,
   onChangeServings,
 }: GroceryMealItemProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, circleStyle } = useTheme();
   return (
     <View
       style={{

--- a/mobile/components/meal-plan/WeekSelector.tsx
+++ b/mobile/components/meal-plan/WeekSelector.tsx
@@ -3,13 +3,7 @@ import { Pressable, Text, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { hapticLight } from '@/lib/haptics';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 import { formatWeekRange } from '@/lib/utils/dateFormatter';
 
 interface WeekSelectorProps {
@@ -31,7 +25,7 @@ export const WeekSelector = ({
   onNextWeek,
   onJumpToToday,
 }: WeekSelectorProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   return (
     <View
       style={{ paddingHorizontal: spacing['2xl'], marginBottom: spacing.lg }}

--- a/mobile/components/recipe-detail/EditRecipeModal.tsx
+++ b/mobile/components/recipe-detail/EditRecipeModal.tsx
@@ -9,13 +9,7 @@ import {
 } from 'react-native';
 import { BottomSheetModal, ChipPicker } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, letterSpacing, spacing, useTheme } from '@/lib/theme';
 import type {
   DietLabel,
   Household,
@@ -62,7 +56,7 @@ export const EditRecipeModal = ({
   onTransferRecipe,
   onDelete,
 }: EditRecipeModalProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const [editDietLabel, setEditDietLabel] = useState<DietLabel | null>(
     recipe.diet_label,
   );

--- a/mobile/components/recipe-detail/EnhancementReviewBanner.tsx
+++ b/mobile/components/recipe-detail/EnhancementReviewBanner.tsx
@@ -6,7 +6,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface EnhancementReviewBannerProps {
   t: TFunction;
@@ -21,7 +21,7 @@ export const EnhancementReviewBanner = ({
   onApprove,
   onReject,
 }: EnhancementReviewBannerProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View
       style={{

--- a/mobile/components/recipe-detail/HouseholdTransfer.tsx
+++ b/mobile/components/recipe-detail/HouseholdTransfer.tsx
@@ -1,13 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, letterSpacing, spacing, useTheme } from '@/lib/theme';
 import type { Household } from '@/lib/types';
 
 interface HouseholdTransferProps {
@@ -25,7 +19,7 @@ export const HouseholdTransfer = ({
   t,
   onTransfer,
 }: HouseholdTransferProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View style={{ marginBottom: spacing.xl }}>
       <Text

--- a/mobile/components/recipe-detail/ImageUrlModal.tsx
+++ b/mobile/components/recipe-detail/ImageUrlModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Modal, Pressable, Text, TextInput, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface ImageUrlModalProps {
   visible: boolean;
@@ -18,7 +18,7 @@ export const ImageUrlModal = ({
   onClose,
   onSave,
 }: ImageUrlModalProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const [imageUrlInput, setImageUrlInput] = useState(initialUrl);
 
   useEffect(() => {

--- a/mobile/components/recipe-detail/InstructionItem.tsx
+++ b/mobile/components/recipe-detail/InstructionItem.tsx
@@ -2,11 +2,9 @@ import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import { IconCircle } from '@/components';
 import {
-  borderRadius,
   fontSize,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -27,7 +25,7 @@ export const InstructionItem = ({
   onToggle,
   stepNumber,
 }: InstructionItemProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   const { type, content, time } = instruction;
 
   if (type === 'tip') {

--- a/mobile/components/recipe-detail/OriginalEnhancedToggle.tsx
+++ b/mobile/components/recipe-detail/OriginalEnhancedToggle.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface OriginalEnhancedToggleProps {
   showOriginal: boolean;
@@ -14,7 +14,7 @@ export const OriginalEnhancedToggle = ({
   t,
   onToggle,
 }: OriginalEnhancedToggleProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View
       style={{

--- a/mobile/components/recipe-detail/PlanMealModal.tsx
+++ b/mobile/components/recipe-detail/PlanMealModal.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { BottomSheetModal } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 import type { MealType } from '@/lib/types';
 import { isPastDate, toBcp47 } from '@/lib/utils/dateFormatter';
 import { DEFAULT_MEAL_TYPES } from './recipe-detail-constants';
@@ -36,7 +36,7 @@ export const PlanMealModal = ({
   onClearMeal,
   getMealForSlot,
 }: PlanMealModalProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const resolvedMealTypes = mealTypesProp ?? DEFAULT_MEAL_TYPES;
 
   return (

--- a/mobile/components/recipe-detail/RecipeActionButtons.tsx
+++ b/mobile/components/recipe-detail/RecipeActionButtons.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { showAlert } from '@/lib/alert';
 import type { TFunction } from '@/lib/i18n';
-import { circleStyle, iconContainer, useTheme } from '@/lib/theme';
+import { iconContainer, useTheme } from '@/lib/theme';
 
 interface RecipeActionButtonsProps {
   canEdit: boolean;
@@ -36,7 +36,7 @@ export const RecipeActionButtons = ({
   onCopy,
   onEnhance,
 }: RecipeActionButtonsProps) => {
-  const { colors } = useTheme();
+  const { colors, circleStyle } = useTheme();
   const enhanceDisabled = isEnhancing || !aiEnabled || !isOwned;
 
   const actionButtonStyle = {

--- a/mobile/components/recipe-detail/RecipeActionsFooter.tsx
+++ b/mobile/components/recipe-detail/RecipeActionsFooter.tsx
@@ -3,7 +3,7 @@ import { Linking, Pressable, Text, View } from 'react-native';
 import { PrimaryButton } from '@/components';
 import { showNotification } from '@/lib/alert';
 import type { TFunction } from '@/lib/i18n';
-import { borderRadius, fontSize, layout, spacing, useTheme } from '@/lib/theme';
+import { fontSize, layout, spacing, useTheme } from '@/lib/theme';
 
 interface RecipeActionsFooterProps {
   url: string;
@@ -16,7 +16,7 @@ export const RecipeActionsFooter = ({
   t,
   onShowPlanModal,
 }: RecipeActionsFooterProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <>
       {url && (

--- a/mobile/components/recipe-detail/RecipeEnhancedInfo.tsx
+++ b/mobile/components/recipe-detail/RecipeEnhancedInfo.tsx
@@ -3,10 +3,8 @@ import { Pressable, Text, View } from 'react-native';
 import { IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
 import {
-  borderRadius,
   fontSize,
   lineHeight,
-  shadows,
   spacing,
   typography,
   useTheme,
@@ -28,7 +26,7 @@ export const RecipeEnhancedInfo = ({
   t,
   onToggleAiChanges,
 }: RecipeEnhancedInfoProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   return (
     <>
       {recipe.enhanced && !showOriginal && recipe.tips && (

--- a/mobile/components/recipe-detail/RecipeHero.tsx
+++ b/mobile/components/recipe-detail/RecipeHero.tsx
@@ -8,13 +8,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, letterSpacing, spacing, useTheme } from '@/lib/theme';
 import {
   PLACEHOLDER_BLURHASH,
   PLACEHOLDER_IMAGE,
@@ -46,7 +40,7 @@ export const RecipeHero = ({
   onThumbUp,
   onThumbDown,
 }: RecipeHeroProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <Animated.View
       style={{

--- a/mobile/components/recipe-detail/RecipeIngredientsList.tsx
+++ b/mobile/components/recipe-detail/RecipeIngredientsList.tsx
@@ -3,10 +3,8 @@ import { Text, View } from 'react-native';
 import { IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
 import {
-  borderRadius,
   fontSize,
   lineHeight,
-  shadows,
   spacing,
   typography,
   useTheme,
@@ -21,7 +19,7 @@ export const RecipeIngredientsList = ({
   ingredients,
   t,
 }: RecipeIngredientsListProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   return (
     <View style={{ marginTop: spacing.xl }}>
       <View

--- a/mobile/components/recipe-detail/RecipeInstructions.tsx
+++ b/mobile/components/recipe-detail/RecipeInstructions.tsx
@@ -3,7 +3,6 @@ import { Pressable, Text, View } from 'react-native';
 import { IconCircle } from '@/components';
 import type { TFunction } from '@/lib/i18n';
 import {
-  borderRadius,
   fontSize,
   lineHeight,
   spacing,
@@ -26,7 +25,7 @@ export const RecipeInstructions = ({
   t,
   onToggleStep,
 }: RecipeInstructionsProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View style={{ marginTop: spacing.xl, marginBottom: spacing.xl }}>
       <View

--- a/mobile/components/recipe-detail/RecipeLoadingStates.tsx
+++ b/mobile/components/recipe-detail/RecipeLoadingStates.tsx
@@ -2,20 +2,14 @@ import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import { BouncingLoader, GradientBackground } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface RecipeLoadingProps {
   structured?: boolean;
 }
 
 export const RecipeLoading = ({ structured = true }: RecipeLoadingProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   return (
     <GradientBackground
       structured={structured}
@@ -44,7 +38,7 @@ interface RecipeNotFoundProps {
 }
 
 export const RecipeNotFound = ({ t, onGoBack }: RecipeNotFoundProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   return (
     <GradientBackground
       structured

--- a/mobile/components/recipe-detail/RecipeMetaLabels.tsx
+++ b/mobile/components/recipe-detail/RecipeMetaLabels.tsx
@@ -1,13 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  dotSize,
-  fontSize,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { dotSize, fontSize, spacing, useTheme } from '@/lib/theme';
 import type { Recipe } from '@/lib/types';
 import { getDietLabels } from './recipe-detail-constants';
 
@@ -17,7 +11,7 @@ interface RecipeMetaLabelsProps {
 }
 
 export const RecipeMetaLabels = ({ recipe, t }: RecipeMetaLabelsProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const dietLabels = getDietLabels(colors);
   return (
     <View

--- a/mobile/components/recipe-detail/RecipeNotes.tsx
+++ b/mobile/components/recipe-detail/RecipeNotes.tsx
@@ -22,7 +22,6 @@ import {
 } from '@/lib/hooks';
 import type { TFunction } from '@/lib/i18n';
 import {
-  borderRadius,
   fontSize,
   lineHeight,
   spacing,
@@ -45,7 +44,7 @@ export const RecipeNotes = ({
   t,
   onCopy,
 }: RecipeNotesProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const [text, setText] = useState('');
   const { data: notes, isLoading } = useRecipeNotes(recipeId);
   const createNote = useCreateRecipeNote();

--- a/mobile/components/recipe-detail/RecipeTags.tsx
+++ b/mobile/components/recipe-detail/RecipeTags.tsx
@@ -1,12 +1,12 @@
 import { Text, View } from 'react-native';
-import { borderRadius, fontSize, spacing, useTheme } from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface RecipeTagsProps {
   tags: string[];
 }
 
 export const RecipeTags = ({ tags }: RecipeTagsProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   if (tags.length === 0) return null;
 
   return (

--- a/mobile/components/recipe-detail/RecipeTimeServings.tsx
+++ b/mobile/components/recipe-detail/RecipeTimeServings.tsx
@@ -1,13 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, spacing, useTheme } from '@/lib/theme';
 
 interface TimeStatProps {
   icon: 'timer' | 'flame' | 'time' | 'people';
@@ -65,7 +59,7 @@ export const RecipeTimeServings = ({
   servings,
   t,
 }: RecipeTimeServingsProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const hasAnyTime = prepTime || cookTime || totalTime;
   if (!hasAnyTime && !servings) return null;
 

--- a/mobile/components/recipe-detail/TagEditor.tsx
+++ b/mobile/components/recipe-detail/TagEditor.tsx
@@ -2,13 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useState } from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, letterSpacing, spacing, useTheme } from '@/lib/theme';
 
 interface TagEditorProps {
   editTags: string;
@@ -17,7 +11,7 @@ interface TagEditorProps {
 }
 
 export const TagEditor = ({ editTags, setEditTags, t }: TagEditorProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   const [newTag, setNewTag] = useState('');
 
   const handleAddTag = () => {

--- a/mobile/components/recipe-detail/ThumbRating.tsx
+++ b/mobile/components/recipe-detail/ThumbRating.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable, View } from 'react-native';
-import { borderRadius, spacing, useTheme } from '@/lib/theme';
+import { spacing, useTheme } from '@/lib/theme';
 
 interface ThumbRatingProps {
   rating: number | null;
@@ -17,7 +17,7 @@ export const ThumbRating = ({
   onThumbDown,
   size = 28,
 }: ThumbRatingProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const isThumbUp = rating === 5;
   const isThumbDown = hidden;
 

--- a/mobile/components/recipes/RecipeFilters.tsx
+++ b/mobile/components/recipes/RecipeFilters.tsx
@@ -8,13 +8,7 @@ import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
 import { AnimatedPressable } from '@/components';
 import { hapticLight } from '@/lib/haptics';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  dotSize,
-  fontSize,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { dotSize, fontSize, spacing, useTheme } from '@/lib/theme';
 import type { DietLabel, LibraryScope } from '@/lib/types';
 
 interface SearchBarProps {
@@ -38,7 +32,7 @@ export const SearchBar = ({
   searchInputRef,
   t,
 }: SearchBarProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   return (
     <View style={{ paddingHorizontal: spacing.xl, paddingBottom: spacing.sm }}>
@@ -121,7 +115,7 @@ export const FilterChips = ({
   onSortPress,
   t,
 }: FilterChipsProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
 
   const dietChips: {
     diet: DietLabel;

--- a/mobile/components/review-recipe/ReviewVersionToggle.tsx
+++ b/mobile/components/review-recipe/ReviewVersionToggle.tsx
@@ -2,13 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Pressable, Text, View } from 'react-native';
 import { SurfaceCard } from '@/components';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, letterSpacing, spacing, useTheme } from '@/lib/theme';
 
 type VersionTab = 'original' | 'enhanced';
 
@@ -23,7 +17,7 @@ export const ReviewVersionToggle = ({
   onSelectTab,
   t,
 }: ReviewVersionToggleProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius } = useTheme();
   return (
     <View style={{ marginBottom: spacing.xl }}>
       <Text

--- a/mobile/components/select-recipe/CopyMealTab.tsx
+++ b/mobile/components/select-recipe/CopyMealTab.tsx
@@ -5,14 +5,11 @@ import { EmptyState } from '@/components/EmptyState';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
 import {
   accentUnderlineStyle,
-  borderRadius,
-  circleStyle,
   fontSize,
   fontWeight,
   iconContainer,
   layout,
   letterSpacing,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -25,7 +22,7 @@ interface CopyMealTabProps {
 }
 
 export const CopyMealTab = ({ state }: CopyMealTabProps) => {
-  const { colors, fonts } = useTheme();
+  const { colors, fonts, borderRadius, shadows, circleStyle } = useTheme();
   const {
     t,
     bcp47,

--- a/mobile/components/select-recipe/LibraryTab.tsx
+++ b/mobile/components/select-recipe/LibraryTab.tsx
@@ -3,14 +3,7 @@ import { FlatList, Pressable, TextInput, View } from 'react-native';
 import { RecipeCard } from '@/components';
 import { EmptyState } from '@/components/EmptyState';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
-import {
-  borderRadius,
-  fontSize,
-  layout,
-  shadows,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, layout, spacing, useTheme } from '@/lib/theme';
 
 type State = ReturnType<typeof useSelectRecipeState>;
 
@@ -19,7 +12,7 @@ interface LibraryTabProps {
 }
 
 export const LibraryTab = ({ state }: LibraryTabProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const {
     t,
     mode,

--- a/mobile/components/select-recipe/QuickMealTab.tsx
+++ b/mobile/components/select-recipe/QuickMealTab.tsx
@@ -4,7 +4,6 @@ import { IconCircle } from '@/components';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
 import {
   accentUnderlineStyle,
-  borderRadius,
   fontSize,
   fontWeight,
   letterSpacing,
@@ -19,7 +18,7 @@ interface QuickMealTabProps {
 }
 
 export const QuickMealTab = ({ state }: QuickMealTabProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const {
     t,
     customText,

--- a/mobile/components/select-recipe/RandomTab.tsx
+++ b/mobile/components/select-recipe/RandomTab.tsx
@@ -6,14 +6,12 @@ import { PrimaryButton } from '@/components/PrimaryButton';
 import type { useSelectRecipeState } from '@/lib/hooks/useSelectRecipeState';
 import {
   accentUnderlineStyle,
-  borderRadius,
   dotSize,
   fontSize,
   fontWeight,
   layout,
   letterSpacing,
   lineHeight,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -25,7 +23,7 @@ interface RandomTabProps {
 }
 
 export const RandomTab = ({ state }: RandomTabProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const {
     t,
     randomRecipe,
@@ -189,7 +187,7 @@ interface RandomRecipeCardProps {
 }
 
 const RandomRecipeCard = ({ recipe, onSelect, t }: RandomRecipeCardProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
 
   return (
     <Pressable

--- a/mobile/components/settings/AccountSection.tsx
+++ b/mobile/components/settings/AccountSection.tsx
@@ -8,12 +8,10 @@ import {
 } from '@/components';
 import { useTranslation } from '@/lib/i18n';
 import {
-  borderRadius,
   fontSize,
   fontWeight,
   settingsSubtitleStyle,
   settingsTitleStyle,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -29,7 +27,7 @@ export const AccountSection = ({
   displayName,
   onSignOut,
 }: AccountSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -114,7 +112,7 @@ export const HouseholdSettingsLink = ({
   isLoading,
   onPress,
 }: HouseholdSettingsLinkProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/settings/FooterSections.tsx
+++ b/mobile/components/settings/FooterSections.tsx
@@ -3,11 +3,9 @@ import { Text, View } from 'react-native';
 import { AnimatedPressable, SectionHeader, SurfaceCard } from '@/components';
 import { useTranslation } from '@/lib/i18n';
 import {
-  borderRadius,
   fontWeight,
   settingsSubtitleStyle,
   settingsTitleStyle,
-  shadows,
   spacing,
   useTheme,
 } from '@/lib/theme';
@@ -17,7 +15,7 @@ interface AdminSectionProps {
 }
 
 export const AdminSection = ({ onNavigateToAdmin }: AdminSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius, shadows } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/settings/ItemsAtHomeSection.tsx
+++ b/mobile/components/settings/ItemsAtHomeSection.tsx
@@ -4,13 +4,7 @@ import { Pressable, Text, TextInput, View } from 'react-native';
 import { IconCircle, SurfaceCard } from '@/components';
 import { showNotification } from '@/lib/alert';
 import { useTranslation } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  fontWeight,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, fontWeight, spacing, useTheme } from '@/lib/theme';
 
 const SUGGESTED_ITEM_KEYS = [
   'salt',
@@ -41,7 +35,7 @@ export const ItemsAtHomeSection = ({
   onAddItem,
   onRemoveItem,
 }: ItemsAtHomeSectionProps) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
   const [newItem, setNewItem] = useState('');
 
@@ -145,7 +139,7 @@ const CurrentItems = ({
   items: string[];
   onRemove: (item: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -209,7 +203,7 @@ const SuggestedItems = ({
   items: string[];
   onAdd: (item: string) => void;
 }) => {
-  const { colors } = useTheme();
+  const { colors, borderRadius } = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/mobile/components/settings/LanguagePicker.tsx
+++ b/mobile/components/settings/LanguagePicker.tsx
@@ -3,13 +3,7 @@ import { Image } from 'expo-image';
 import { Pressable, Text, View } from 'react-native';
 import { SurfaceCard } from '@/components';
 import { type AppLanguage, LANGUAGES } from '@/lib/settings-context';
-import {
-  circleStyle,
-  fontSize,
-  iconContainer,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, iconContainer, spacing, useTheme } from '@/lib/theme';
 
 const FLAG_URLS: Record<AppLanguage, string> = {
   en: 'https://flagcdn.com/w80/gb.png',
@@ -26,7 +20,7 @@ export const LanguagePicker = ({
   currentLanguage,
   onChangeLanguage,
 }: LanguagePickerProps) => {
-  const { colors } = useTheme();
+  const { colors, circleStyle } = useTheme();
 
   return (
     <SurfaceCard style={{ overflow: 'hidden' }} padding={0}>

--- a/mobile/lib/theme.ts
+++ b/mobile/lib/theme.ts
@@ -5,7 +5,11 @@
 
 export type { ColorTokens } from './theme/colors';
 export { colors, lightColors } from './theme/colors';
-export type { IconContainerSize } from './theme/layout';
+export type {
+  BorderRadiusTokens,
+  IconContainerSize,
+  ShadowTokens,
+} from './theme/layout';
 export {
   animation,
   borderRadius,
@@ -25,7 +29,12 @@ export {
   settingsSubtitleStyle,
   settingsTitleStyle,
 } from './theme/styles';
-export { terminalColors } from './theme/terminal-colors';
+export {
+  terminalBorderRadius,
+  terminalColors,
+  terminalShadows,
+} from './theme/terminal-colors';
+export type { CircleStyleFn } from './theme/theme-context';
 export { ThemeProvider, useTheme } from './theme/theme-context';
 export type { FontFamilyTokens } from './theme/typography';
 export {

--- a/mobile/lib/theme/layout.ts
+++ b/mobile/lib/theme/layout.ts
@@ -61,6 +61,11 @@ export const borderRadius = {
   full: 9999,
 } as const;
 
+/** Structural contract for border radius scales. */
+export type BorderRadiusTokens = {
+  readonly [K in keyof typeof borderRadius]: number;
+};
+
 // Icon sizes - standardized
 export const iconSize = {
   xs: 14,
@@ -108,6 +113,11 @@ export const shadows = {
   cardRaised: { boxShadow: '2px 6px 16px 0px rgba(0, 0, 0, 0.1)' },
   float: { boxShadow: '1px 2px 8px 0px rgba(0, 0, 0, 0.15)' },
 } as const;
+
+/** Structural contract for shadow presets. */
+export type ShadowTokens = {
+  readonly [K in keyof typeof shadows]: { readonly boxShadow: string };
+};
 
 // Animation durations - smooth, premium feel
 export const animation = {

--- a/mobile/lib/theme/styles.ts
+++ b/mobile/lib/theme/styles.ts
@@ -7,15 +7,18 @@
 
 import type { ColorTokens } from './colors';
 import { colors } from './colors';
-import { borderRadius, spacing } from './layout';
+import { type BorderRadiusTokens, borderRadius, spacing } from './layout';
 import { fontSize, fontWeight } from './typography';
 
 /** Build style presets for a given color palette. */
-export const createStyles = (c: ColorTokens) =>
+export const createStyles = (
+  c: ColorTokens,
+  radii: BorderRadiusTokens = borderRadius,
+) =>
   ({
     inputStyle: {
       backgroundColor: c.white,
-      borderRadius: borderRadius.md,
+      borderRadius: radii.md,
       paddingHorizontal: spacing.lg,
       paddingVertical: spacing.md,
       fontSize: fontSize.lg,

--- a/mobile/lib/theme/terminal-colors.ts
+++ b/mobile/lib/theme/terminal-colors.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ColorTokens } from './colors';
+import type { BorderRadiusTokens, ShadowTokens } from './layout';
 
 // ── Base palette ───────────────────────────────────────────────────────
 const BLACK = '#0A0A0A';
@@ -258,4 +259,37 @@ export const terminalColors: ColorTokens = {
   },
 
   tagDot: [GREEN, CYAN, GREEN_DIM, GREEN_DARK, CYAN_DIM, AMBER, RED, BLUE],
+};
+
+// ── Terminal border radius — sharp corners, no rounding ────────────────
+export const terminalBorderRadius: BorderRadiusTokens = {
+  '3xs': 0,
+  '2xs': 0,
+  'xs-sm': 0,
+  xs: 0,
+  'sm-md': 0,
+  sm: 0,
+  'md-lg': 0,
+  md: 0,
+  lg: 0,
+  'lg-xl': 0,
+  xl: 0,
+  full: 0,
+};
+
+// ── Terminal shadows — flat screen, no depth ───────────────────────────
+const NONE = { boxShadow: '0px 0px 0px 0px transparent' } as const;
+
+export const terminalShadows: ShadowTokens = {
+  none: NONE,
+  xs: NONE,
+  sm: NONE,
+  card: NONE,
+  md: NONE,
+  lg: NONE,
+  xl: NONE,
+  glow: { boxShadow: '0px 0px 8px 0px rgba(51, 255, 51, 0.3)' },
+  glowSoft: { boxShadow: '0px 0px 4px 0px rgba(51, 255, 51, 0.15)' },
+  cardRaised: NONE,
+  float: NONE,
 };

--- a/mobile/test/setup.ts
+++ b/mobile/test/setup.ts
@@ -345,6 +345,24 @@ vi.mock('@/lib/theme', () => {
     accent: 'DMSans_500Medium',
   };
 
+  const mockBorderRadius = { '3xs': 3, '2xs': 4, 'xs-sm': 6, xs: 8, 'sm-md': 10, sm: 12, 'md-lg': 14, md: 16, lg: 20, 'lg-xl': 22, xl: 24, full: 9999 };
+
+  const mockShadows = {
+    none: { boxShadow: '0px 0px 0px 0px transparent' },
+    xs: { boxShadow: '1px 1px 2px 0px rgba(0, 0, 0, 0.03)' },
+    sm: { boxShadow: '1px 2px 6px 0px rgba(0, 0, 0, 0.04)' },
+    card: { boxShadow: '1px 2px 6px 0px rgba(0, 0, 0, 0.06)' },
+    md: { boxShadow: '2px 4px 12px 0px rgba(0, 0, 0, 0.06)' },
+    lg: { boxShadow: '2px 8px 20px 0px rgba(0, 0, 0, 0.08)' },
+    xl: { boxShadow: '3px 12px 28px 0px rgba(0, 0, 0, 0.12)' },
+    glow: { boxShadow: '1px 4px 16px 0px rgba(232, 168, 124, 0.25)' },
+    glowSoft: { boxShadow: '1px 2px 10px 0px rgba(232, 168, 124, 0.15)' },
+    cardRaised: { boxShadow: '2px 6px 16px 0px rgba(0, 0, 0, 0.1)' },
+    float: { boxShadow: '1px 2px 8px 0px rgba(0, 0, 0, 0.15)' },
+  };
+
+  const mockCircleStyle = (size: number) => ({ width: size, height: size, borderRadius: size / 2 });
+
   return {
   colors: c,
   lightColors: undefined, // re-exported but unused in tests
@@ -366,22 +384,10 @@ vi.mock('@/lib/theme', () => {
       overlayBottomOffset: 60,
     },
   },
-  borderRadius: { '3xs': 3, '2xs': 4, 'xs-sm': 6, xs: 8, 'sm-md': 10, sm: 12, 'md-lg': 14, md: 16, lg: 20, 'lg-xl': 22, xl: 24, full: 9999 },
+  borderRadius: mockBorderRadius,
   iconSize: { xs: 14, sm: 16, md: 18, lg: 20, xl: 24, '2xl': 32, '3xl': 40 },
   iconContainer: { xs: 36, sm: 32, md: 40, lg: 48, xl: 56, '2xl': 80 },
-  shadows: {
-    none: { boxShadow: '0px 0px 0px 0px transparent' },
-    xs: { boxShadow: '1px 1px 2px 0px rgba(0, 0, 0, 0.03)' },
-    sm: { boxShadow: '1px 2px 6px 0px rgba(0, 0, 0, 0.04)' },
-    card: { boxShadow: '1px 2px 6px 0px rgba(0, 0, 0, 0.06)' },
-    md: { boxShadow: '2px 4px 12px 0px rgba(0, 0, 0, 0.06)' },
-    lg: { boxShadow: '2px 8px 20px 0px rgba(0, 0, 0, 0.08)' },
-    xl: { boxShadow: '3px 12px 28px 0px rgba(0, 0, 0, 0.12)' },
-    glow: { boxShadow: '1px 4px 16px 0px rgba(232, 168, 124, 0.25)' },
-    glowSoft: { boxShadow: '1px 2px 10px 0px rgba(232, 168, 124, 0.15)' },
-    cardRaised: { boxShadow: '2px 6px 16px 0px rgba(0, 0, 0, 0.1)' },
-    float: { boxShadow: '1px 2px 8px 0px rgba(0, 0, 0, 0.15)' },
-  },
+  shadows: mockShadows,
   animation: { fast: 150, normal: 250, slow: 350, spring: { damping: 15, stiffness: 100 } },
   fontSize: { xs: 10, sm: 11, base: 12, md: 13, lg: 14, xl: 15, 'lg-xl': 16, '2xl': 17, 'xl-2xl': 18, '3xl': 20, '4xl': 26, '3xl-4xl': 28, '5xl': 32, '6xl': 40 },
   fontWeight: { light: '300', normal: '400', medium: '500', semibold: '600', bold: '700' },
@@ -414,7 +420,7 @@ vi.mock('@/lib/theme', () => {
   settingsSubtitleStyle: { fontSize: 13, color: 'rgba(93, 78, 64, 0.6)' },
   accentUnderlineStyle: { width: 40, height: 3, borderRadius: 2, backgroundColor: '#6B8E6B' },
   createStyles: () => mockStyles,
-  circleStyle: (size: number) => ({ width: size, height: size, borderRadius: size / 2 }),
+  circleStyle: mockCircleStyle,
   dotSize: { md: 10 },
   lineHeight: { sm: 18, md: 20, lg: 22, xl: 24, '2xl': 26 },
   defaultFontFamily: mockFonts,
@@ -429,10 +435,27 @@ vi.mock('@/lib/theme', () => {
     bodyBold: 'Courier',
     accent: 'Courier',
   },
+  terminalBorderRadius: { '3xs': 0, '2xs': 0, 'xs-sm': 0, xs: 0, 'sm-md': 0, sm: 0, 'md-lg': 0, md: 0, lg: 0, 'lg-xl': 0, xl: 0, full: 0 },
+  terminalShadows: {
+    none: { boxShadow: '0px 0px 0px 0px transparent' },
+    xs: { boxShadow: '0px 0px 0px 0px transparent' },
+    sm: { boxShadow: '0px 0px 0px 0px transparent' },
+    card: { boxShadow: '0px 0px 0px 0px transparent' },
+    md: { boxShadow: '0px 0px 0px 0px transparent' },
+    lg: { boxShadow: '0px 0px 0px 0px transparent' },
+    xl: { boxShadow: '0px 0px 0px 0px transparent' },
+    glow: { boxShadow: '0px 0px 8px 0px rgba(51, 255, 51, 0.3)' },
+    glowSoft: { boxShadow: '0px 0px 4px 0px rgba(51, 255, 51, 0.15)' },
+    cardRaised: { boxShadow: '0px 0px 0px 0px transparent' },
+    float: { boxShadow: '0px 0px 0px 0px transparent' },
+  },
   useTheme: () => ({
     colors: c,
     fonts: mockFonts,
     styles: mockStyles,
+    borderRadius: mockBorderRadius,
+    shadows: mockShadows,
+    circleStyle: mockCircleStyle,
   }),
   ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
   };


### PR DESCRIPTION
## Summary

Migrate `borderRadius`, `shadows`, and `circleStyle` from static imports to `useTheme()` context, making them theme-switchable at runtime. Terminal CRT theme gets sharp corners (all radii = 0), flat shadows, and square `IconCircle`.

## Infrastructure

- **`layout.ts`** — Added `BorderRadiusTokens` and `ShadowTokens` types alongside existing constants
- **`terminal-colors.ts`** — Added `terminalBorderRadius` (all 0) and `terminalShadows` (flat, with green glow for `glow`/`glowSoft`)
- **`theme-context.tsx`** — Extended `ThemeValue` with `borderRadius`, `shadows`, `circleStyle`; `ThemeProvider` accepts optional `radii` and `shadowTokens` props; terminal `circleStyle` returns `borderRadius: 0`
- **`styles.ts`** — `createStyles` now accepts `BorderRadiusTokens` parameter
- **`_layout.tsx`** — Passes terminal shape tokens when `EXPO_PUBLIC_THEME=terminal`
- **`test/setup.ts`** — Mock updated with all three tokens in `useTheme()` return

## Migration

70+ consumer files migrated from static `import { borderRadius, shadows }` to `const { borderRadius, shadows } = useTheme()`. Pattern identical to the fontFamily migration in PR #290.

StyleSheet.create files (EnhancementReviewModal, EnhancingOverlay, FloatingTabBar, PrimaryButton) had their theme tokens moved from module-scope stylesheets to inline styles within component bodies.

## Exceptions

- **Skeleton.tsx** — Retains static `borderRadius` import (used as default parameter value, naming conflict with hook destructuring)
- **ErrorBoundary.tsx** — Class component, cannot use hooks

## Stats

- **89 files changed**, +354 / -532 (net -178 lines)
- **559 tests passing**, 0 TypeScript errors
- Follows same migration pattern as PRs #286-287 (colors) and #290 (fonts)
