### PR TITLE
fix(ci): use env vars for secret file reconstruction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ You are collaborating with a human who may make changes between your edits:
 - **Read before editing** - the human may have modified, moved, or intentionally removed content
 - **Verify suggestions** - when given review comments or suggestions, verify they are correct against actual code before applying
 - **Compare alternatives** - when the user suggests a different approach, analyze both options and explain the tradeoffs
+- **Stop and ask when blocked by environment** - when a failure is caused by something outside your control (locked files, permission errors, GUI-only actions, expired auth, running processes), stop immediately and ask the user for help. The human can often resolve these in seconds. Do not spend tokens on workarounds — describe the blocker and what the user can do to fix it
 - **Troubleshoot step-by-step** - when debugging, suggest one fix at a time and wait for results
 - **Exploratory questions → answer only** - when asked "how", "why", or "what would the changes be", answer the question only. NEVER start implementing. Wait for explicit instruction to proceed
 - **Answer questions before acting** - when the user asks a question (including "why did you do X?"), answer the question first. Do not silently correct or move on. Ask before proceeding to fix

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -51,11 +51,15 @@ jobs:
 
       - name: Reconstruct access files and tfvars
         working-directory: ${{ env.TF_DIR }}
+        env:
+          TF_SUPERUSERS_CONTENT: ${{ secrets.TF_SUPERUSERS }}
+          TF_USERS_CONTENT: ${{ secrets.TF_USERS }}
+          TF_VARS_CONTENT: ${{ secrets.TF_VARS_FILE }}
         run: |
           mkdir -p access
-          printf '%s\n' "${{ secrets.TF_SUPERUSERS }}" > access/superusers.txt
-          printf '%s\n' "${{ secrets.TF_USERS }}" > access/users.txt
-          printf '%s\n' '${{ secrets.TF_VARS_FILE }}' > terraform.tfvars
+          printenv TF_SUPERUSERS_CONTENT > access/superusers.txt
+          printenv TF_USERS_CONTENT > access/users.txt
+          printenv TF_VARS_CONTENT > terraform.tfvars
 
           # Partial backend config — actual bucket/prefix come from -backend-config flags
           printf 'terraform {\n  backend "gcs" {}\n}\n' > backend.tf

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -78,11 +78,15 @@ jobs:
 
       - name: Reconstruct gitignored files
         working-directory: ${{ env.TF_DIR }}
+        env:
+          TF_SUPERUSERS_CONTENT: ${{ secrets.TF_SUPERUSERS }}
+          TF_USERS_CONTENT: ${{ secrets.TF_USERS }}
+          TF_VARS_CONTENT: ${{ secrets.TF_VARS_FILE }}
         run: |
           mkdir -p access
-          printf '%s\n' "${{ secrets.TF_SUPERUSERS }}" > access/superusers.txt
-          printf '%s\n' "${{ secrets.TF_USERS }}" > access/users.txt
-          printf '%s\n' '${{ secrets.TF_VARS_FILE }}' > terraform.tfvars
+          printenv TF_SUPERUSERS_CONTENT > access/superusers.txt
+          printenv TF_USERS_CONTENT > access/users.txt
+          printenv TF_VARS_CONTENT > terraform.tfvars
 
           # Partial backend config — actual bucket/prefix come from -backend-config flags
           printf 'terraform {\n  backend "gcs" {}\n}\n' > backend.tf


### PR DESCRIPTION
Fixes all Terraform CI failures since ~March 15 (PRs #422, #428, #430, #436, #441).

**Root cause:** The "Reconstruct gitignored files" step used inline secret expansion:

```bash
printf '%s\n' '${{ secrets.TF_VARS_FILE }}' > terraform.tfvars
```

When the secret contained HCL list syntax with single quotes (after adding `firebase_authorized_domains`), it broke shell quoting. The shell interpreted variable names as commands, causing exit code 127 and skipping init/validate/plan.

**Fix:** Pass secrets via `env:` block and write with `printenv`, avoiding shell interpretation of secret content.

Also adds a collaboration guideline for Copilot to stop and ask when blocked by environment issues.
