### PR TITLE
chore: disable Renovate for setup-trivy post-compromise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -97,6 +97,13 @@
         "mobile/**"
       ],
       "allowedVersions": "<4.0.0"
+    },
+    {
+      "description": "setup-trivy digest lookup broken post-compromise; pinned to verified SHA",
+      "matchPackageNames": [
+        "aquasecurity/setup-trivy"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Digest lookup is broken after the March 2026 supply chain attack on aquasecurity repos. We are already pinned to verified SHA 3fb12ec (v0.2.6) — no updates needed. Silences the Renovate warning.