### PR TITLE
fix: grocery list not created when stale removed_items hide all items

### DIFF
--- a/mobile/lib/__tests__/grocery-context.test.tsx
+++ b/mobile/lib/__tests__/grocery-context.test.tsx
@@ -284,6 +284,48 @@ describe('GroceryProvider', () => {
       expect(mockPatchGroceryState).toHaveBeenCalledWith({
         selected_meals: ['monday-lunch', 'tuesday-dinner'],
         meal_servings: { 'monday-lunch': 4, 'tuesday-dinner': 2 },
+        removed_items: [],
+      });
+    });
+
+    it('clears removed items but preserves checked items when saving new selections', async () => {
+      mockGetGroceryState.mockResolvedValue({
+        ...emptyState,
+        selected_meals: ['monday-lunch'],
+        meal_servings: { 'monday-lunch': 2 },
+        checked_items: ['flour', 'sugar'],
+        removed_items: ['butter'],
+      });
+
+      mockPatchGroceryState.mockResolvedValue({
+        ...emptyState,
+        selected_meals: ['tuesday-dinner'],
+        meal_servings: { 'tuesday-dinner': 4 },
+        checked_items: ['flour', 'sugar'],
+        removed_items: [],
+      });
+
+      const { result } = renderHook(() => useGroceryState(), {
+        wrapper: createGroceryWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.checkedItems.size).toBe(2);
+      expect(result.current.removedItems).toEqual(['butter']);
+
+      await act(async () => {
+        await result.current.saveSelections(
+          ['tuesday-dinner'],
+          { 'tuesday-dinner': 4 },
+        );
+      });
+
+      expect(result.current.checkedItems.size).toBe(2);
+      expect(result.current.removedItems).toEqual([]);
+      expect(mockPatchGroceryState).toHaveBeenCalledWith({
+        selected_meals: ['tuesday-dinner'],
+        meal_servings: { 'tuesday-dinner': 4 },
+        removed_items: [],
       });
     });
   });

--- a/mobile/lib/grocery-context.tsx
+++ b/mobile/lib/grocery-context.tsx
@@ -357,7 +357,7 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
         clearTimeout(patchTimerRef.current);
         patchTimerRef.current = null;
       }
-      pendingPatchRef.current = {};
+      await flushPatch();
 
       setSelectedMealKeys(meals);
       setMealServings(servings);
@@ -387,7 +387,7 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
         mealServings: response.meal_servings || {},
       });
     },
-    [applyState],
+    [applyState, flushPatch],
   );
 
   const clearAll = useCallback(async () => {

--- a/mobile/lib/grocery-context.tsx
+++ b/mobile/lib/grocery-context.tsx
@@ -353,8 +353,17 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
 
   const saveSelections = useCallback(
     async (meals: string[], servings: Record<string, number>) => {
+      if (patchTimerRef.current) {
+        clearTimeout(patchTimerRef.current);
+        patchTimerRef.current = null;
+      }
+      pendingPatchRef.current = {};
+
       setSelectedMealKeys(meals);
       setMealServings(servings);
+      setRemovedItemsState([]);
+      removedItemsRef.current = [];
+
       AsyncStorage.setItem(
         'grocery_selected_meals',
         JSON.stringify(meals),
@@ -366,6 +375,7 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
       const response = await api.patchGroceryState({
         selected_meals: meals,
         meal_servings: servings,
+        removed_items: [],
       });
       applyState(response);
       cacheToAsyncStorage({

--- a/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
+++ b/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
@@ -55,7 +55,11 @@ vi.mock('@/lib/hooks', () => ({
   useUpdateNote: vi.fn(() => ({ mutate: mockMutate })),
   useRemoveMeal: vi.fn(() => ({ mutate: mockRemoveMutate })),
   useUpdateExtras: vi.fn(() => ({ mutate: mockUpdateExtrasMutate })),
-  useGroceryState: vi.fn(() => ({ saveSelections: mockSaveSelections })),
+  useGroceryState: vi.fn(() => ({
+    saveSelections: mockSaveSelections,
+    selectedMealKeys: [] as string[],
+    mealServings: {} as Record<string, number>,
+  })),
 }));
 
 vi.mock('expo-router', () => ({
@@ -207,6 +211,31 @@ describe('useMealPlanActions', () => {
         { '2026-01-05_lunch': 4 },
       );
       expect(result.current.showGroceryModal).toBe(false);
+    });
+
+    it('merges new meals with existing selections from context', async () => {
+      const { useGroceryState } = await import('@/lib/hooks');
+      vi.mocked(useGroceryState).mockReturnValue({
+        saveSelections: mockSaveSelections,
+        selectedMealKeys: ['2026-01-06_dinner'],
+        mealServings: { '2026-01-06_dinner': 2 },
+      } as unknown as ReturnType<typeof useGroceryState>);
+
+      const { result } = renderActions();
+
+      act(() => result.current.handleToggleMeal(new Date('2026-01-05'), 'lunch', 4));
+      await act(() => result.current.handleCreateGroceryList());
+
+      expect(mockSaveSelections).toHaveBeenCalledWith(
+        expect.arrayContaining(['2026-01-06_dinner', '2026-01-05_lunch']),
+        { '2026-01-06_dinner': 2, '2026-01-05_lunch': 4 },
+      );
+
+      vi.mocked(useGroceryState).mockReturnValue({
+        saveSelections: mockSaveSelections,
+        selectedMealKeys: [] as string[],
+        mealServings: {} as Record<string, number>,
+      } as unknown as ReturnType<typeof useGroceryState>);
     });
   });
 

--- a/mobile/lib/hooks/useMealPlanActions.ts
+++ b/mobile/lib/hooks/useMealPlanActions.ts
@@ -23,7 +23,11 @@ export const useMealPlanActions = () => {
   const router = useRouter();
   const { t, language } = useTranslation();
   const { weekStart, settings } = useSettings();
-  const { saveSelections } = useGroceryState();
+  const {
+    saveSelections,
+    selectedMealKeys: existingMealKeys,
+    mealServings: existingServings,
+  } = useGroceryState();
 
   const MEAL_TYPES: MealTypeOption[] = useMemo(() => {
     const types: MealTypeOption[] = [];
@@ -402,14 +406,24 @@ export const useMealPlanActions = () => {
       return;
     }
     try {
-      const mealsArray = Array.from(selectedMeals);
-      await saveSelections(mealsArray, mealServings);
+      const newMeals = Array.from(selectedMeals);
+      const mergedMeals = [...new Set([...existingMealKeys, ...newMeals])];
+      const mergedServings = { ...existingServings, ...mealServings };
+      await saveSelections(mergedMeals, mergedServings);
       setShowGroceryModal(false);
       setTimeout(() => router.push('/(tabs)/grocery'), 100);
     } catch {
       showNotification(t('common.error'), t('mealPlan.failedToSaveSelections'));
     }
-  }, [selectedMeals, mealServings, router, t, saveSelections]);
+  }, [
+    selectedMeals,
+    mealServings,
+    existingMealKeys,
+    existingServings,
+    router,
+    t,
+    saveSelections,
+  ]);
 
   const openGroceryModal = useCallback(() => {
     hapticLight();


### PR DESCRIPTION
## Problem

When clicking the cart button in the weekly menu, selecting meals, and creating a grocery list, **no items appeared** in the shopping list. This happened because:

1. `saveSelections` only patched `selected_meals` and `meal_servings` to Firestore, leaving stale `removed_items` from a previous grocery list session
2. The grocery screen filtered out all generated items that matched the old `removed_items`, resulting in an empty list
3. Creating a grocery list from a second set of meals **replaced** the first selection instead of merging

## Fix

### `grocery-context.tsx` — `saveSelections`
- Clears `removed_items` (both local state and Firestore) so previously cleared items don't hide newly generated ones
- Flushes any pending debounced patch to avoid race conditions
- **Preserves** `checked_items` so in-progress shopping isn't lost

### `useMealPlanActions.ts` — `handleCreateGroceryList`
- Merges new meal selections with existing `selectedMealKeys` from the grocery context
- Merges servings maps so existing servings are preserved
- Multiple cart button presses now build up the list additively

## Tests

- Updated existing `saveSelections` test to verify `removed_items: []` is sent in PATCH
- Added test: checked items are preserved while removed items are cleared
- Added test: new meals merge with existing selections from context
- All 95 related tests pass