### PR TITLE
refactor: rename salad meal label to side_dish

### DIFF
--- a/api/models/recipe.py
+++ b/api/models/recipe.py
@@ -81,7 +81,7 @@ class MealLabel(str, Enum):
 
     BREAKFAST = "breakfast"
     STARTER = "starter"
-    SALAD = "salad"
+    SIDE_DISH = "side_dish"
     MEAL = "meal"
     DESSERT = "dessert"
     DRINK = "drink"

--- a/mobile/components/recipe-detail/recipe-detail-constants.ts
+++ b/mobile/components/recipe-detail/recipe-detail-constants.ts
@@ -60,7 +60,7 @@ export const MEAL_OPTIONS: { value: MealLabel | null; labelKey: string }[] = [
   { value: null, labelKey: 'labels.meal.none' },
   { value: 'breakfast', labelKey: 'labels.meal.breakfast' },
   { value: 'starter', labelKey: 'labels.meal.starter' },
-  { value: 'salad', labelKey: 'labels.meal.salad' },
+  { value: 'side_dish', labelKey: 'labels.meal.side_dish' },
   { value: 'meal', labelKey: 'labels.meal.mainCourse' },
   { value: 'dessert', labelKey: 'labels.meal.dessert' },
   { value: 'drink', labelKey: 'labels.meal.drink' },

--- a/mobile/components/recipes/MealTypePicker.tsx
+++ b/mobile/components/recipes/MealTypePicker.tsx
@@ -13,7 +13,7 @@ import type { MealLabel } from '@/lib/types';
 const MEAL_TYPE_ICONS: Record<MealLabel, IoniconName> = {
   breakfast: 'cafe-outline',
   starter: 'flame-outline',
-  salad: 'leaf-outline',
+  side_dish: 'leaf-outline',
   meal: 'restaurant-outline',
   dessert: 'ice-cream-outline',
   drink: 'wine-outline',
@@ -25,7 +25,7 @@ const MEAL_TYPE_ICONS: Record<MealLabel, IoniconName> = {
 const MEAL_TYPES: MealLabel[] = [
   'breakfast',
   'starter',
-  'salad',
+  'side_dish',
   'meal',
   'dessert',
   'drink',

--- a/mobile/components/recipes/__tests__/MealTypePicker.test.tsx
+++ b/mobile/components/recipes/__tests__/MealTypePicker.test.tsx
@@ -11,7 +11,7 @@ const mockT = (key: string) => {
   const translations: Record<string, string> = {
     'labels.meal.breakfast': 'Breakfast',
     'labels.meal.starter': 'Starter',
-    'labels.meal.salad': 'Salad',
+    'labels.meal.side_dish': 'Side Dish',
     'labels.meal.meal': 'Meal',
     'labels.meal.dessert': 'Dessert',
     'labels.meal.drink': 'Drink',
@@ -38,7 +38,7 @@ describe('MealTypePicker', () => {
 
     expect(screen.getByText('Breakfast')).toBeDefined();
     expect(screen.getByText('Starter')).toBeDefined();
-    expect(screen.getByText('Salad')).toBeDefined();
+    expect(screen.getByText('Side Dish')).toBeDefined();
     expect(screen.getByText('Meal')).toBeDefined();
     expect(screen.getByText('Dessert')).toBeDefined();
     expect(screen.getByText('Drink')).toBeDefined();
@@ -58,23 +58,23 @@ describe('MealTypePicker', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('Salad'));
-    expect(handleToggle).toHaveBeenCalledWith('salad');
+    fireEvent.click(screen.getByText('Side Dish'));
+    expect(handleToggle).toHaveBeenCalledWith('side_dish');
   });
 
   it('calls onToggle for already-selected type (deselect)', () => {
     const handleToggle = vi.fn();
     render(
       <MealTypePicker
-        selected={['salad']}
+        selected={['side_dish']}
         onToggle={handleToggle}
         onClear={vi.fn()}
         t={mockT}
       />,
     );
 
-    fireEvent.click(screen.getByText('Salad'));
-    expect(handleToggle).toHaveBeenCalledWith('salad');
+    fireEvent.click(screen.getByText('Side Dish'));
+    expect(handleToggle).toHaveBeenCalledWith('side_dish');
   });
 
   it('does not show clear button when nothing selected', () => {
@@ -93,7 +93,7 @@ describe('MealTypePicker', () => {
   it('shows clear button when types are selected', () => {
     render(
       <MealTypePicker
-        selected={['salad', 'drink']}
+        selected={['side_dish', 'drink']}
         onToggle={vi.fn()}
         onClear={vi.fn()}
         t={mockT}

--- a/mobile/lib/i18n/locales/en.ts
+++ b/mobile/lib/i18n/locales/en.ts
@@ -46,7 +46,7 @@ const en = {
       all: 'All',
       breakfast: 'Breakfast',
       starter: 'Starter',
-      salad: 'Salad',
+      side_dish: 'Side Dish',
       meal: 'Meal',
       mainCourse: 'Main Course',
       dessert: 'Dessert',

--- a/mobile/lib/i18n/locales/it.ts
+++ b/mobile/lib/i18n/locales/it.ts
@@ -45,7 +45,7 @@ const it: Translations = {
       all: 'Tutti',
       breakfast: 'Colazione',
       starter: 'Antipasto',
-      salad: 'Insalata',
+      side_dish: 'Contorno',
       meal: 'Pasto',
       mainCourse: 'Piatto principale',
       dessert: 'Dolce',

--- a/mobile/lib/i18n/locales/sv.ts
+++ b/mobile/lib/i18n/locales/sv.ts
@@ -45,7 +45,7 @@ const sv: Translations = {
       all: 'Alla',
       breakfast: 'Frukost',
       starter: 'Förrätt',
-      salad: 'Sallad',
+      side_dish: 'Tillbehör',
       meal: 'Måltid',
       mainCourse: 'Huvudrätt',
       dessert: 'Efterrätt',

--- a/mobile/lib/types.ts
+++ b/mobile/lib/types.ts
@@ -9,7 +9,7 @@ export type LibraryScope = 'all' | 'mine';
 export type MealLabel =
   | 'breakfast'
   | 'starter'
-  | 'salad'
+  | 'side_dish'
   | 'meal'
   | 'dessert'
   | 'drink'

--- a/scripts/migrate_salad_to_side_dish.py
+++ b/scripts/migrate_salad_to_side_dish.py
@@ -1,0 +1,58 @@
+"""Migrate meal_label from 'salad' to 'side_dish' on existing recipes.
+
+The 'salad' meal label has been renamed to 'side_dish'. This script
+updates all Firestore recipes that still have meal_label='salad'.
+
+Usage:
+    uv run python scripts/migrate_salad_to_side_dish.py [--dry-run]
+"""
+
+import argparse
+import sys
+
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from api.storage.firestore_client import RECIPES_COLLECTION, get_firestore_client
+
+
+def migrate(*, dry_run: bool = False) -> None:
+    db = get_firestore_client()
+    docs = db.collection(RECIPES_COLLECTION).where(filter=FieldFilter("meal_label", "==", "salad")).stream()
+
+    updated = 0
+
+    for doc in docs:
+        title = doc.to_dict().get("title", "(untitled)")
+
+        if dry_run:
+            print(f"  [DRY RUN] {doc.id} ({title}): would change salad → side_dish")
+        else:
+            doc.reference.update({"meal_label": "side_dish"})
+            print(f"  {doc.id} ({title}): salad → side_dish")
+
+        updated += 1
+
+    if updated == 0:
+        print("No recipes with meal_label='salad' found.")
+    else:
+        action = "Would update" if dry_run else "Updated"
+        print(f"\n{action} {updated} recipe(s).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate meal_label from 'salad' to 'side_dish'")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without writing to Firestore")
+    args = parser.parse_args()
+
+    print("Migrating meal_label: salad → side_dish...")
+    if args.dry_run:
+        print("(DRY RUN — no changes will be written)\n")
+
+    migrate(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/tests/test_api_recipes.py
+++ b/tests/test_api_recipes.py
@@ -880,7 +880,7 @@ class TestParseRecipe:
             mock_client_class.return_value = mock_client
 
             response = client.post(
-                "/recipes/parse?diet_label=fish&meal_label=salad",
+                "/recipes/parse?diet_label=fish&meal_label=side_dish",
                 json={
                     "url": "https://example.com/fish-salad",
                     "html": "<html><head><title>Fish</title></head><body>" + "x" * 100 + "</body></html>",
@@ -890,7 +890,7 @@ class TestParseRecipe:
         assert response.status_code == 201
         saved_create = mock_save.call_args[0][0]
         assert saved_create.diet_label.value == "fish"
-        assert saved_create.meal_label.value == "salad"
+        assert saved_create.meal_label.value == "side_dish"
 
 
 class TestPreviewRecipe:


### PR DESCRIPTION
Renames the `salad` meal category to `side_dish` across the entire stack.

## Changes
- **API**: Update `MealLabel` enum value from `SALAD = "salad"` to `SIDE_DISH = "side_dish"`
- **Mobile**: Update `MealLabel` type, `MealTypePicker`, recipe-detail constants
- **i18n**: Update all 3 locale files (en, sv, it) with new translations
- **Tests**: Update API and mobile test assertions
- **Migration**: Add `scripts/migrate_salad_to_side_dish.py` to update existing Firestore recipes

## Post-merge action
Run the migration script to update existing recipes in Firestore:
```bash
uv run python -m scripts.migrate_salad_to_side_dish --dry-run  # preview
uv run python -m scripts.migrate_salad_to_side_dish             # apply
```