### PR TITLE
fix: persist grocery item reorder to active store order

### DIFF
--- a/api/routers/grocery.py
+++ b/api/routers/grocery.py
@@ -302,3 +302,23 @@ async def learn_store_order(
         save_store_order(household_id, store_id, updated_order)
         return LearnOrderResponse(updated=True, item_order=updated_order)
     return LearnOrderResponse(updated=False, item_order=current_order)
+
+
+class SetStoreOrderRequest(BaseModel):
+    """Request body for directly setting a store's item ordering."""
+
+    item_order: list[str] = Field(..., description="Complete item ordering to save")
+
+
+@router.put("/stores/{store_id}/order")
+async def set_store_item_order(
+    store_id: str, body: SetStoreOrderRequest, user: Annotated[AuthenticatedUser, Depends(require_auth)]
+) -> StoreOrderResponse:
+    """Directly set the item ordering for a store.
+
+    Used when the user manually reorders items via drag-and-drop.
+    Replaces the entire stored ordering for the given store.
+    """
+    household_id = require_household(user)
+    save_store_order(household_id, store_id, body.item_order)
+    return StoreOrderResponse(item_order=body.item_order)

--- a/mobile/lib/api/mealPlans.ts
+++ b/mobile/lib/api/mealPlans.ts
@@ -108,6 +108,16 @@ export const groceryApi = {
     });
   },
 
+  setStoreOrder: (
+    storeId: string,
+    itemOrder: string[],
+  ): Promise<StoreOrderResponse> => {
+    return apiRequest<StoreOrderResponse>(`/grocery/stores/${storeId}/order`, {
+      method: 'PUT',
+      body: JSON.stringify({ item_order: itemOrder }),
+    });
+  },
+
   setActiveStore: (
     storeId: string | null,
   ): Promise<{ active_store_id: string | null }> => {

--- a/mobile/lib/hooks/__tests__/useGroceryScreen.test.ts
+++ b/mobile/lib/hooks/__tests__/useGroceryScreen.test.ts
@@ -100,9 +100,11 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 const mockLearnStoreOrder = vi.fn().mockResolvedValue({ updated: false, item_order: [] });
+const mockSetStoreOrder = vi.fn().mockResolvedValue({ item_order: [] });
 vi.mock('@/lib/api', () => ({
   api: {
     learnStoreOrder: (...args: unknown[]) => mockLearnStoreOrder(...args),
+    setStoreOrder: (...args: unknown[]) => mockSetStoreOrder(...args),
   },
 }));
 
@@ -124,6 +126,7 @@ describe('useGroceryScreen', () => {
     focusCallbacks = [];
     focusCleanups = [];
     mockLearnStoreOrder.mockResolvedValue({ updated: false, item_order: [] });
+    mockSetStoreOrder.mockResolvedValue({ item_order: [] });
     mockContextState = {
       checkedItems: new Set<string>(),
       customItems: [],
@@ -813,6 +816,27 @@ describe('useGroceryScreen', () => {
       });
 
       expect(mockSetItemOrder).toHaveBeenCalledWith(['eggs', 'bread', 'milk']);
+    });
+
+    it('saves to store order when active store is set', async () => {
+      const { useSettings } = await import('@/lib/settings-context');
+      vi.mocked(useSettings).mockReturnValue({
+        isItemAtHome: vi.fn(() => false),
+        activeStoreId: 'store_1',
+        settings: null,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useSettings>);
+
+      const { result } = renderHook(() => useGroceryScreen());
+
+      act(() => {
+        result.current.handleReorder([
+          { name: 'eggs', category: 'dairy', checked: false, quantity: null, unit: null, quantity_sources: [], recipe_sources: [] },
+          { name: 'bread', category: 'bakery', checked: false, quantity: null, unit: null, quantity_sources: [], recipe_sources: [] },
+        ]);
+      });
+
+      expect(mockSetStoreOrder).toHaveBeenCalledWith('store_1', ['eggs', 'bread']);
     });
   });
 

--- a/mobile/lib/hooks/__tests__/useGroceryScreen.test.ts
+++ b/mobile/lib/hooks/__tests__/useGroceryScreen.test.ts
@@ -818,7 +818,7 @@ describe('useGroceryScreen', () => {
       expect(mockSetItemOrder).toHaveBeenCalledWith(['eggs', 'bread', 'milk']);
     });
 
-    it('saves to store order when active store is set', async () => {
+    it('saves to store order when active store is set, preserving hidden items', async () => {
       const { useSettings } = await import('@/lib/settings-context');
       vi.mocked(useSettings).mockReturnValue({
         isItemAtHome: vi.fn(() => false),
@@ -827,16 +827,22 @@ describe('useGroceryScreen', () => {
         isLoading: false,
       } as unknown as ReturnType<typeof useSettings>);
 
+      mockStoreOrderData = { item_order: ['eggs', 'bread', 'cheese', 'butter'] };
+
       const { result } = renderHook(() => useGroceryScreen());
 
       act(() => {
         result.current.handleReorder([
-          { name: 'eggs', category: 'dairy', checked: false, quantity: null, unit: null, quantity_sources: [], recipe_sources: [] },
           { name: 'bread', category: 'bakery', checked: false, quantity: null, unit: null, quantity_sources: [], recipe_sources: [] },
+          { name: 'eggs', category: 'dairy', checked: false, quantity: null, unit: null, quantity_sources: [], recipe_sources: [] },
         ]);
       });
 
-      expect(mockSetStoreOrder).toHaveBeenCalledWith('store_1', ['eggs', 'bread']);
+      expect(mockSetStoreOrder).toHaveBeenCalledWith('store_1', ['bread', 'eggs', 'cheese', 'butter']);
+      expect(mockSetQueryData).toHaveBeenCalledWith(
+        ['grocery', 'storeOrder', 'store_1'],
+        { item_order: ['bread', 'eggs', 'cheese', 'butter'] },
+      );
     });
   });
 

--- a/mobile/lib/hooks/useGroceryScreen.ts
+++ b/mobile/lib/hooks/useGroceryScreen.ts
@@ -227,21 +227,29 @@ export const useGroceryScreen = () => {
 
   const handleReorder = useCallback(
     (items: GroceryItem[]) => {
-      const order = items.map((i) => i.name);
-      setItemOrder(order);
+      const reorderedNames = items.map((i) => i.name);
+      setItemOrder(reorderedNames);
 
       if (activeStoreId) {
-        api
-          .setStoreOrder(activeStoreId, order)
-          .then((response) => {
-            queryClient.setQueryData(groceryKeys.storeOrder(activeStoreId), {
-              item_order: response.item_order,
-            });
-          })
-          .catch(() => {});
+        const existingOrder = storeOrderData?.item_order ?? [];
+        const reorderedSet = new Set(reorderedNames);
+        const preserved = existingOrder.filter(
+          (name) => !reorderedSet.has(name),
+        );
+        const merged = [...reorderedNames, ...preserved];
+
+        queryClient.setQueryData(groceryKeys.storeOrder(activeStoreId), {
+          item_order: merged,
+        });
+
+        api.setStoreOrder(activeStoreId, merged).catch(() => {
+          queryClient.setQueryData(groceryKeys.storeOrder(activeStoreId), {
+            item_order: existingOrder,
+          });
+        });
       }
     },
-    [setItemOrder, activeStoreId, queryClient],
+    [setItemOrder, activeStoreId, storeOrderData, queryClient],
   );
 
   const MIN_TICK_SEQUENCE_LENGTH = 2;

--- a/mobile/lib/hooks/useGroceryScreen.ts
+++ b/mobile/lib/hooks/useGroceryScreen.ts
@@ -227,9 +227,21 @@ export const useGroceryScreen = () => {
 
   const handleReorder = useCallback(
     (items: GroceryItem[]) => {
-      setItemOrder(items.map((i) => i.name));
+      const order = items.map((i) => i.name);
+      setItemOrder(order);
+
+      if (activeStoreId) {
+        api
+          .setStoreOrder(activeStoreId, order)
+          .then((response) => {
+            queryClient.setQueryData(groceryKeys.storeOrder(activeStoreId), {
+              item_order: response.item_order,
+            });
+          })
+          .catch(() => {});
+      }
     },
-    [setItemOrder],
+    [setItemOrder, activeStoreId, queryClient],
   );
 
   const MIN_TICK_SEQUENCE_LENGTH = 2;

--- a/tests/test_api_store_order.py
+++ b/tests/test_api_store_order.py
@@ -135,6 +135,30 @@ class TestLearnStoreOrder:
         mock_save.assert_called_once()
 
 
+class TestSetStoreOrder:
+    """Tests for PUT /grocery/stores/{store_id}/order."""
+
+    def test_saves_order_directly(self, client: TestClient) -> None:
+        with patch("api.routers.grocery.save_store_order") as mock_save:
+            response = client.put("/grocery/stores/store_1/order", json={"item_order": ["C", "A", "B"]})
+
+        assert response.status_code == 200
+        assert response.json()["item_order"] == ["C", "A", "B"]
+        mock_save.assert_called_once_with("test_household", "store_1", ["C", "A", "B"])
+
+    def test_saves_empty_order(self, client: TestClient) -> None:
+        with patch("api.routers.grocery.save_store_order") as mock_save:
+            response = client.put("/grocery/stores/store_1/order", json={"item_order": []})
+
+        assert response.status_code == 200
+        assert response.json()["item_order"] == []
+        mock_save.assert_called_once_with("test_household", "store_1", [])
+
+    def test_requires_household(self, client_no_household: TestClient) -> None:
+        response = client_no_household.put("/grocery/stores/store_1/order", json={"item_order": ["A"]})
+        assert response.status_code == 403
+
+
 class TestSetActiveStore:
     """Tests for PUT /grocery/active-store."""
 


### PR DESCRIPTION
## Problem
When manually reordering grocery items via drag-and-drop, the new order was saved to `item_order` in the grocery state, but the display prioritizes the store-specific order (`storeOrder`) when an active store is selected. This caused the reorder to appear lost immediately after saving.

## Fix
- Add `PUT /grocery/stores/{store_id}/order` endpoint to directly set a store's item ordering
- Update `handleReorder` to also save to the active store's order when a store is selected
- Add `setStoreOrder` API client method

## Tests
- 3 new API tests for the PUT store order endpoint
- 1 new mobile test verifying reorder saves to store order when active store is set
- All 1070 API tests and 816 mobile tests pass