### PR TITLE
feat(mobile): add Petrol theme

### DIFF
--- a/.github/workflows/cache-update.yml
+++ b/.github/workflows/cache-update.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: "24"
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10
 
       - name: Cache mobile node_modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: "24"
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10
 
       - name: Install dependencies
         working-directory: mobile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: "24"
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10
 
       - name: Cache pnpm store
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -93,7 +93,7 @@ jobs:
           node-version: "24"
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10
 
       - name: Cache pnpm store
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/mobile/lib/theme/petrol-colors.ts
+++ b/mobile/lib/theme/petrol-colors.ts
@@ -1,0 +1,469 @@
+/**
+ * Petrol theme — modern minimalist palette built around a deep
+ * petrol-blue accent.
+ *
+ * Cool off-white surfaces, generous neutrals, ink-dark text, and a
+ * single confident accent color (`#0E5C6F`) used sparingly for primary
+ * actions, focus, and brand moments. Designed to feel calm, editorial,
+ * and contemporary — the antithesis of the warm "Elegant" palette.
+ */
+
+import type { ColorTokens } from './colors';
+
+// ── Base palette ───────────────────────────────────────────────────────
+
+/** Signature petrol — deep blue-green, the only saturated color. */
+const PETROL = '#0E5C6F';
+const PETROL_DARK = '#0A4654';
+const PETROL_DEEP = '#073744';
+const PETROL_LIGHT = '#3A8A9C';
+const PETROL_SOFT = '#7FB5BF';
+const PETROL_TINT = '#D4E6EA';
+const PETROL_WASH = '#EAF2F4';
+
+/** Cool, paper-like neutrals. */
+const PAPER = '#F7F8F8';
+const PAPER_LIGHT = '#FCFCFC';
+const PAPER_MID = '#F1F2F3';
+const PAPER_DEEP = '#E7E9EA';
+
+/** Ink — near-black with a faint cool cast for headings/body. */
+const INK = '#11181C';
+const INK_BODY = '#1F2A2E';
+const INK_MUTED = '#5A6A6E';
+const INK_SOFT = '#8A969A';
+const INK_FAINT = '#B7BFC2';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const rgba = (r: number, g: number, b: number, a: number): string =>
+  `rgba(${r}, ${g}, ${b}, ${a})`;
+
+/** Petrol at varying alpha — used for subtle surfaces, hovers, focus. */
+const petrolA = (a: number): string => rgba(14, 92, 111, a);
+/** Ink at varying alpha — used for borders, dividers, secondary text. */
+const inkA = (a: number): string => rgba(17, 24, 28, a);
+
+// ── Palette ────────────────────────────────────────────────────────────
+
+export const petrolColors: ColorTokens = {
+  // Primary — deep ink, used for high-emphasis text and structural anchors.
+  primary: INK,
+  primaryDark: '#000000',
+  primaryLight: INK_BODY,
+
+  // Backgrounds — cool paper neutrals.
+  bgBase: PAPER,
+  bgLight: PAPER_LIGHT,
+  bgMid: PAPER_MID,
+  bgDark: PAPER_DEEP,
+  bgWarm: PAPER,
+
+  // Accent — petrol, the single saturated brand color.
+  accent: PETROL,
+  accentDark: PETROL_DARK,
+  accentLight: PETROL_SOFT,
+  coral: PETROL_LIGHT,
+  coralSoft: PETROL_TINT,
+  gold: '#B89968',
+  goldLight: '#E5D9C2',
+
+  // Category colors — desaturated, on cool washes.
+  category: {
+    recipes: { bg: PETROL_WASH, text: PETROL_DARK },
+    planned: { bg: PAPER_MID, text: INK_BODY },
+    grocery: { bg: '#EFEFF1', text: INK_BODY },
+    add: { bg: PETROL_TINT, text: PETROL_DARK },
+  },
+
+  // Diet — muted, modern.
+  diet: {
+    veggie: {
+      bg: '#E6EFE6',
+      text: '#3F6B45',
+      cardBg: rgba(63, 107, 69, 0.1),
+      border: rgba(63, 107, 69, 0.55),
+    },
+    fish: {
+      bg: PETROL_WASH,
+      text: PETROL_DARK,
+      cardBg: petrolA(0.1),
+      border: petrolA(0.55),
+    },
+    meat: {
+      bg: '#F1E2E0',
+      text: '#8C3F39',
+      cardBg: rgba(140, 63, 57, 0.1),
+      border: rgba(140, 63, 57, 0.55),
+    },
+  },
+
+  // Neutrals
+  white: '#FFFFFF',
+  offWhite: PAPER_LIGHT,
+  text: {
+    primary: INK,
+    secondary: INK_MUTED,
+    muted: INK_SOFT,
+    light: INK_FAINT,
+    inverse: '#FFFFFF',
+    dark: INK,
+  },
+  border: inkA(0.1),
+  borderLight: inkA(0.06),
+  borderFaint: inkA(0.03),
+
+  // Content — ink hierarchy.
+  content: {
+    heading: INK,
+    headingMuted: inkA(0.7),
+    headingWarm: INK_BODY,
+    body: INK_BODY,
+    secondary: INK_MUTED,
+    strong: inkA(0.85),
+    tertiary: inkA(0.65),
+    subtitle: inkA(0.55),
+    icon: inkA(0.5),
+    placeholder: inkA(0.4),
+    placeholderHex: '#11181C66',
+  },
+
+  // Interactive surfaces — nearly invisible washes.
+  surface: {
+    overlay: inkA(0.85),
+    overlayMedium: inkA(0.7),
+    border: inkA(0.1),
+    borderLight: inkA(0.07),
+    divider: inkA(0.08),
+    dividerSolid: PAPER_DEEP,
+    modal: '#FFFFFF',
+    pressed: inkA(0.06),
+    active: inkA(0.04),
+    subtle: inkA(0.03),
+    hover: inkA(0.02),
+    tint: inkA(0.015),
+    sheetOverlay: 'rgba(247, 248, 248, 0.96)',
+    iconBg: petrolA(0.08),
+  },
+
+  // Buttons — petrol primary.
+  button: {
+    primary: PETROL,
+    primaryPressed: PETROL_DARK,
+    primaryText: '#FFFFFF',
+    disabled: '#C5CDCF',
+    primarySubtle: petrolA(0.06),
+    primarySurface: petrolA(0.08),
+    primaryActive: petrolA(0.12),
+    primaryHover: petrolA(0.16),
+    primaryDivider: petrolA(0.22),
+  },
+
+  // Neutral gray scale.
+  gray: {
+    50: '#FAFAFA',
+    100: '#F4F5F5',
+    200: '#E8EAEA',
+    300: '#D4D7D8',
+    400: '#A8ADAF',
+    500: '#7C8285',
+    600: '#5C6266',
+    700: '#42484B',
+    800: '#2A2F32',
+    900: '#15191B',
+  },
+
+  // Semantic — restrained, modern hues.
+  success: '#3F8C5C',
+  successBg: '#E5F1EA',
+  warning: '#C58A2C',
+  warningBg: '#F7EFDD',
+  error: '#C24A45',
+  errorBg: '#F4E1E0',
+  info: PETROL,
+  infoBg: PETROL_WASH,
+  danger: '#B23A35',
+
+  // Overlays — neutral darks.
+  overlay: {
+    backdrop: 'rgba(17, 24, 28, 0.5)',
+    backdropLight: 'rgba(17, 24, 28, 0.35)',
+    strong: 'rgba(17, 24, 28, 0.65)',
+    gradientHeavy: 'rgba(17, 24, 28, 0.7)',
+    gradientSubtle: 'rgba(17, 24, 28, 0.12)',
+  },
+
+  // Meal plan surfaces — clean white tinted with petrol wash.
+  mealPlan: {
+    slotBg: 'rgba(255, 255, 255, 0.92)',
+    containerBg: 'rgba(255, 255, 255, 0.98)',
+    emptyBg: 'rgba(247, 248, 248, 0.7)',
+    emptyStateBg: 'rgba(234, 242, 244, 0.5)',
+  },
+
+  // Ratings — calm green / muted red.
+  rating: {
+    positive: '#5A8A6B',
+    negative: '#B25A55',
+    positiveBg: 'rgba(90, 138, 107, 0.22)',
+    negativeBg: 'rgba(178, 90, 85, 0.22)',
+  },
+
+  // Timeline — petrol spine.
+  timeline: {
+    badge: PETROL,
+    line: petrolA(0.18),
+    completedText: PETROL_DARK,
+  },
+
+  // Chips / filters — unified soft wash (DE-style minimalism).
+  chip: {
+    bg: inkA(0.04),
+    border: 'transparent',
+    divider: inkA(0.06),
+    fishActive: PETROL,
+    meatActive: '#8C3F39',
+    favoriteActive: '#B23A35',
+    mealTypeActive: PETROL_DARK,
+    toggleActiveBg: petrolA(0.1),
+    toggleInactiveBg: inkA(0.04),
+    toggleActiveBorder: 'transparent',
+    toggleActiveText: PETROL_DARK,
+    toggleInactiveText: INK_BODY,
+  },
+
+  // Text shadow.
+  shadow: {
+    text: 'rgba(0, 0, 0, 0.12)',
+  },
+
+  // Glass — crisp, near-opaque whites.
+  glass: {
+    light: 'rgba(255, 255, 255, 0.94)',
+    medium: 'rgba(255, 255, 255, 0.82)',
+    heavy: 'rgba(255, 255, 255, 0.97)',
+    solid: '#FFFFFF',
+    bright: 'rgba(255, 255, 255, 0.94)',
+    dark: 'rgba(255, 255, 255, 0.65)',
+    subtle: 'rgba(255, 255, 255, 0.6)',
+    faint: 'rgba(255, 255, 255, 0.5)',
+    card: 'rgba(255, 255, 255, 0.95)',
+    border: inkA(0.05),
+    button: 'rgba(255, 255, 255, 0.35)',
+    buttonPressed: 'rgba(255, 255, 255, 0.5)',
+    buttonDefault: 'rgba(255, 255, 255, 0.4)',
+    dim: 'rgba(255, 255, 255, 0.1)',
+    pressed: 'rgba(255, 255, 255, 0.18)',
+  },
+
+  // Fixed header — page bg with slight transparency.
+  header: {
+    bg: 'rgba(247, 248, 248, 0.88)',
+    fadeEnd: 'rgba(247, 248, 248, 0)',
+    shadow: '0px 1px 8px rgba(17, 24, 28, 0.06)',
+    fadeWidth: 24,
+  },
+
+  // Tab bar — minimal floating bar (matches Elegant chrome).
+  tabBar: {
+    bg: 'rgba(255, 255, 255, 0.7)',
+    bgFallback: 'rgba(255, 255, 255, 0.92)',
+    bottomFill: PAPER,
+    border: inkA(0.06),
+    active: PETROL,
+    inactive: INK_MUTED,
+    focusBg: petrolA(0.08),
+  },
+
+  // AI accent — leans on petrol family for cohesion.
+  ai: {
+    primary: PETROL,
+    primaryDark: PETROL_DARK,
+    bg: petrolA(0.07),
+    bgPressed: petrolA(0.16),
+    muted: petrolA(0.5),
+    iconBg: petrolA(0.1),
+    light: petrolA(0.13),
+    badge: petrolA(0.95),
+    selectedBg: petrolA(0.1),
+    border: petrolA(0.28),
+  },
+
+  // Destructive — modern muted red.
+  destructive: {
+    bg: 'rgba(178, 58, 53, 0.1)',
+    icon: 'rgba(178, 58, 53, 0.85)',
+    text: 'rgba(178, 58, 53, 0.92)',
+  },
+
+  // Decorative gradient — cool mist with petrol depth.
+  gradient: {
+    orb1: '#EAF2F4',
+    orb2: '#D4E6EA',
+    orb3: '#E7E9EA',
+    orb4: PETROL_SOFT,
+    orb5: '#F1F4F5',
+    orb6: PETROL_LIGHT,
+    stop1: '#D4E6EA',
+    stop2: '#EAF2F4',
+  },
+
+  // Background overlays for GradientBackground.
+  background: {
+    mutedOverlay: 'rgba(17, 24, 28, 0.08)',
+    defaultOverlay: 'rgba(255, 255, 255, 0.06)',
+    structuredWash: 'rgba(247, 248, 248, 0.96)',
+    structuredGradientStart: 'rgba(212, 230, 234, 0.18)',
+    structuredGradientEnd: 'transparent',
+    animatedOverlay: 'rgba(255, 255, 255, 0.06)',
+  },
+
+  // Tag dots — restrained palette built around petrol family.
+  tagDot: [
+    PETROL, // petrol
+    '#5A8A9A', // dusty teal
+    '#7C9A8A', // sage
+    '#B89968', // warm tan
+    '#8C3F39', // brick
+    '#5A6A8A', // slate blue
+    '#9A7C8A', // mauve
+    '#3F6B45', // forest
+  ] as readonly string[],
+
+  // ── Semantic component tokens ────────────────────────────────────────
+
+  card: {
+    bg: 'rgba(255, 255, 255, 0.95)',
+    bgPressed: 'rgba(255, 255, 255, 0.88)',
+    textPrimary: INK,
+    textSecondary: INK_MUTED,
+    borderColor: inkA(0.05),
+  },
+
+  searchBar: {
+    bg: 'rgba(255, 255, 255, 0.95)',
+    border: inkA(0.06),
+    icon: INK_MUTED,
+    text: INK,
+    placeholder: INK_SOFT,
+    clearIcon: 'rgba(255, 255, 255, 0.6)',
+    cancelText: PETROL,
+  },
+
+  input: {
+    bg: 'rgba(255, 255, 255, 0.95)',
+    bgSubtle: inkA(0.03),
+    border: 'transparent',
+    text: INK,
+    placeholder: INK_SOFT,
+  },
+
+  toggle: {
+    trackBg: 'rgba(255, 255, 255, 0.4)',
+    activeBg: 'rgba(255, 255, 255, 0.9)',
+    activeText: INK,
+    inactiveText: INK_MUTED,
+    borderColor: 'transparent',
+    switchTrackOff: inkA(0.18),
+    switchTrackOn: PETROL,
+    switchThumbOff: '#D4D7D8',
+    switchThumbOn: '#FFFFFF',
+  },
+
+  metaChip: {
+    mealBg: inkA(0.04),
+    mealText: INK_BODY,
+    visibilityBg: inkA(0.04),
+    visibilityText: INK_BODY,
+  },
+
+  checkbox: {
+    checkedBg: PETROL,
+    checkedBorder: PETROL,
+  },
+
+  listItem: {
+    bg: 'rgba(255, 255, 255, 0.96)',
+    bgActive: '#FFFFFF',
+    checkedText: INK_SOFT,
+  },
+
+  // Stats cards (home screen) — borderless, soft shadow only.
+  statsCard: {
+    bg: '#FFFFFF',
+    borderColor: 'transparent',
+  },
+
+  dayCard: {
+    bg: 'rgba(255, 255, 255, 0.96)',
+    bgToday: petrolA(0.08),
+  },
+
+  segmentedControl: {
+    trackBg: inkA(0.04),
+    activeBg: '#FFFFFF',
+    activeText: INK,
+    inactiveText: INK_MUTED,
+  },
+
+  tones: {
+    default: { bg: PETROL, fg: '#FFFFFF', pressed: PETROL_DARK },
+    alt: {
+      bg: inkA(0.06),
+      fg: INK,
+      pressed: inkA(0.12),
+    },
+    cancel: {
+      bg: inkA(0.05),
+      fg: INK_MUTED,
+      pressed: inkA(0.1),
+    },
+    warning: {
+      bg: 'rgba(178, 58, 53, 0.1)',
+      fg: '#B23A35',
+      pressed: 'rgba(178, 58, 53, 0.2)',
+    },
+    ai: {
+      bg: petrolA(0.08),
+      fg: PETROL,
+      pressed: petrolA(0.18),
+    },
+    glass: {
+      bg: 'rgba(255, 255, 255, 0.35)',
+      fg: '#FFFFFF',
+      pressed: 'rgba(255, 255, 255, 0.5)',
+    },
+    glassSolid: {
+      // Soft petrol-tinted wash so icon buttons read as actual buttons
+      // against the white card surface (instead of bare floating icons).
+      bg: petrolA(0.07),
+      fg: PETROL_DARK,
+      pressed: petrolA(0.13),
+    },
+    glassAi: {
+      bg: petrolA(0.07),
+      fg: PETROL,
+      pressed: petrolA(0.13),
+    },
+    glassSubtle: {
+      bg: inkA(0.04),
+      fg: INK_MUTED,
+      pressed: inkA(0.08),
+    },
+    glassCoral: {
+      bg: 'rgba(255, 255, 255, 0.35)',
+      fg: PETROL_LIGHT,
+      pressed: 'rgba(255, 255, 255, 0.5)',
+    },
+    subtle: {
+      bg: inkA(0.04),
+      fg: INK_MUTED,
+      pressed: inkA(0.1),
+    },
+    danger: {
+      bg: '#B23A35',
+      fg: '#FFFFFF',
+      pressed: '#8E2C28',
+    },
+  },
+};

--- a/mobile/lib/theme/themes/index.ts
+++ b/mobile/lib/theme/themes/index.ts
@@ -12,12 +12,14 @@
 import type { ThemeDefinition } from '../theme-context';
 import { bubblegumTheme } from './bubblegum';
 import { lightTheme } from './light';
+import { petrolTheme } from './petrol';
 import { terminalTheme } from './terminal';
 
 // ── Theme list — first entry is the default ────────────────────────────
 
 const allThemes: ThemeDefinition[] = [
   lightTheme,
+  petrolTheme,
   terminalTheme,
   bubblegumTheme,
 ];
@@ -46,4 +48,4 @@ export const allRequiredFonts: Record<string, number> = Object.assign(
 export const isThemeId = (value: string): boolean => value in themes;
 
 // Re-export individual themes for direct access
-export { bubblegumTheme, lightTheme, terminalTheme };
+export { bubblegumTheme, lightTheme, petrolTheme, terminalTheme };

--- a/mobile/lib/theme/themes/petrol.ts
+++ b/mobile/lib/theme/themes/petrol.ts
@@ -1,0 +1,180 @@
+/**
+ * Petrol theme — "Petrol"
+ *
+ * Editorial minimalism inspired by modern recipe magazines:
+ *   • Deep petrol-blue accent (`#0E5C6F`) on cool paper-white surfaces.
+ *   • DM Serif Display for headings — confident, magazine-like display type.
+ *   • DM Sans for body — clean, generous, easy to read.
+ *   • Pill-shaped buttons & meta chips, very rounded — soft, approachable.
+ *   • Solid dark tab bar with white icons, anchored to the bottom.
+ *   • Quiet layered shadows for restrained depth.
+ */
+
+import {
+  DMSans_400Regular,
+  DMSans_500Medium,
+  DMSans_600SemiBold,
+  DMSans_700Bold,
+} from '@expo-google-fonts/dm-sans';
+import { DMSerifDisplay_400Regular } from '@expo-google-fonts/dm-serif-display';
+import { Platform } from 'react-native';
+
+import { borderRadius, type ShadowTokens } from '../layout';
+import { petrolColors } from '../petrol-colors';
+import type {
+  ButtonDisplayConfig,
+  StyleOverrides,
+  ThemeDefinition,
+  VisibilityTokens,
+} from '../theme-context';
+import type { FontFamilyTokens } from '../typography';
+
+// ── Typography — editorial serif display + clean sans body ─────────────
+
+const isWeb = Platform.OS === 'web';
+
+const SERIF = isWeb
+  ? '"DM Serif Display", Georgia, "Times New Roman", serif'
+  : 'DMSerifDisplay_400Regular';
+
+const SANS = isWeb ? '"DM Sans", sans-serif' : 'DMSans_400Regular';
+const SANS_MEDIUM = isWeb ? '"DM Sans", sans-serif' : 'DMSans_500Medium';
+const SANS_SEMIBOLD = isWeb ? '"DM Sans", sans-serif' : 'DMSans_600SemiBold';
+const SANS_BOLD = isWeb ? '"DM Sans", sans-serif' : 'DMSans_700Bold';
+
+const petrolFonts: FontFamilyTokens = {
+  // Display = serif. Used for hero titles, screen headings, recipe names.
+  display: SERIF,
+  displayRegular: SERIF,
+  displayMedium: SERIF,
+  displayBold: SERIF,
+  // Body = sans. Calm and legible for descriptions, lists, UI chrome.
+  body: SANS,
+  bodyMedium: SANS_MEDIUM,
+  bodySemibold: SANS_SEMIBOLD,
+  bodyBold: SANS_BOLD,
+  // Accent = uppercase eyebrow labels ("MAINS", "TOTAL TIME") — sans medium.
+  accent: SANS_MEDIUM,
+};
+
+// ── Border radii — pill-friendly, generous curves ──────────────────────
+
+/**
+ * Petrol uses very rounded shapes:
+ *   • small chrome (chips, badges) → pill (`full`)
+ *   • cards/containers → soft rounded
+ *   • buttons → pill via `buttonRadius`
+ */
+const petrolRadii = {
+  ...borderRadius,
+  '3xs': 4,
+  '2xs': 6,
+  'xs-sm': 8,
+  xs: 10,
+  'sm-md': 12,
+  sm: 14,
+  'md-lg': 16,
+  md: 18,
+  lg: 22,
+  'lg-xl': 26,
+  xl: 28,
+  '2xl': 32,
+  full: 9999,
+} as const;
+
+// ── Style overrides ────────────────────────────────────────────────────
+
+const overrides: StyleOverrides = {
+  checkedOpacity: 0.78,
+  checkboxBorderWidth: 1.5,
+  dashedBorderWidth: 1,
+  cardBorderWidth: 0,
+  cardHighlightBorderWidth: 0,
+  segmentedControlGap: 6,
+  segmentedControlPadding: 4,
+  segmentedControlActiveIndicator: 'underline',
+  chipToggleGap: 8,
+};
+
+// ── Visibility ─────────────────────────────────────────────────────────
+
+const visibility: VisibilityTokens = {
+  showStackHeader: true,
+  showTodayDot: true,
+  showTodayBadge: true,
+  showDayNotes: true,
+  showChevrons: true,
+  showStatIcons: true,
+  showProgressBar: true,
+  showAddItemLabel: true,
+  showEmptyStateIcon: true,
+  showHeroOverlay: true,
+  showRecipeActionButtons: true,
+  showVisibilityChip: true,
+  showRecipeTags: true,
+  showFrameLabels: false,
+  showChipToggleDot: true,
+  showStatDividers: false,
+  showSectionHeaderIcon: false,
+  showCheckmarkIndicator: true,
+};
+
+// ── Shadows — quiet, layered lift (no warmth, low alpha) ───────────────
+
+const petrolShadows: ShadowTokens = {
+  none: { boxShadow: '0px 0px 0px 0px transparent' },
+  xs: { boxShadow: '0px 1px 2px 0px rgba(17, 24, 28, 0.04)' },
+  sm: { boxShadow: '0px 1px 3px 0px rgba(17, 24, 28, 0.06)' },
+  card: { boxShadow: '0px 2px 6px 0px rgba(17, 24, 28, 0.05)' },
+  md: { boxShadow: '0px 3px 8px 0px rgba(17, 24, 28, 0.07)' },
+  lg: { boxShadow: '0px 6px 16px 0px rgba(17, 24, 28, 0.08)' },
+  xl: { boxShadow: '0px 12px 28px 0px rgba(17, 24, 28, 0.1)' },
+  glow: { boxShadow: '0px 0px 16px 0px rgba(14, 92, 111, 0.18)' },
+  glowSoft: { boxShadow: '0px 0px 10px 0px rgba(14, 92, 111, 0.12)' },
+  cardRaised: { boxShadow: '0px 4px 12px 0px rgba(17, 24, 28, 0.08)' },
+  float: { boxShadow: '0px 8px 20px 0px rgba(17, 24, 28, 0.1)' },
+};
+
+// ── Button config — circular icon buttons, soft pill labels ────────────
+
+const buttonDisplay: ButtonDisplayConfig = {
+  display: 'both',
+  wrapper: 'animated',
+  shape: 'circle',
+  interaction: 'scale',
+};
+
+// ── Theme definition ───────────────────────────────────────────────────
+
+export const petrolTheme: ThemeDefinition = {
+  id: 'petrol',
+  name: 'Petrol',
+  pickerSwatch: { type: 'color', value: '#0E5C6F' },
+  colors: petrolColors,
+  fonts: petrolFonts,
+  borderRadius: petrolRadii,
+  shadows: petrolShadows,
+  buttonDisplay,
+  overrides,
+  visibility,
+  tabBar: {
+    borderRadius: 16,
+    borderWidth: 0.5,
+    blur: true,
+    blurIntensity: 40,
+    blurTint: 'light',
+  },
+  chrome: 'full',
+  toggleStyle: 'switch',
+  // Circular icon containers — matches the floating circular FABs in the inspo.
+  iconContainerRadius: 0.5,
+  // Pill-shaped buttons.
+  buttonRadius: 9999,
+  requiredFonts: {
+    DMSans_400Regular,
+    DMSans_500Medium,
+    DMSans_600SemiBold,
+    DMSans_700Bold,
+    DMSerifDisplay_400Regular,
+  },
+};

--- a/mobile/lib/theme/themes/petrol.ts
+++ b/mobile/lib/theme/themes/petrol.ts
@@ -6,7 +6,7 @@
  *   • DM Serif Display for headings — confident, magazine-like display type.
  *   • DM Sans for body — clean, generous, easy to read.
  *   • Pill-shaped buttons & meta chips, very rounded — soft, approachable.
- *   • Solid dark tab bar with white icons, anchored to the bottom.
+ *   • Floating glass tab bar with petrol-tinted active state.
  *   • Quiet layered shadows for restrained depth.
  */
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@expo-google-fonts/dm-sans": "^0.4.2",
+    "@expo-google-fonts/dm-serif-display": "^0.4.2",
     "@expo-google-fonts/noto-emoji": "^0.4.6",
     "@expo/ngrok": "^4.1.0",
     "@expo/vector-icons": "^15.0.3",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@expo-google-fonts/dm-sans':
         specifier: ^0.4.2
         version: 0.4.2
+      '@expo-google-fonts/dm-serif-display':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@expo-google-fonts/noto-emoji':
         specifier: ^0.4.6
         version: 0.4.6
@@ -908,6 +911,9 @@ packages:
 
   '@expo-google-fonts/dm-sans@0.4.2':
     resolution: {integrity: sha512-e/fLH5aCJzkEenz7axvEn8N7IJAKhUwNjIxS75h9j+Ip1M9S7d22M19gJN3A7QW4egVkBJRyQh1hQFhngQn9yA==}
+
+  '@expo-google-fonts/dm-serif-display@0.4.2':
+    resolution: {integrity: sha512-onlO8xAzsgMbKcwUE+fAgJ5AFHhk06VtaDN7eQOJwjV65QIciDKTiSNu1ymHc4m6g/x6D9OqPIYPXdTNIfaEaA==}
 
   '@expo-google-fonts/material-symbols@0.4.24':
     resolution: {integrity: sha512-1bJ63Yv2Bn8SN2MjrlbwLwUhnC8COOeejd15H88WjCtw5iNErqEPaBnpvmYyqciVYwudGo5drUIdY9C/5yPGbg==}
@@ -5464,6 +5470,8 @@ snapshots:
   '@exodus/bytes@1.15.0': {}
 
   '@expo-google-fonts/dm-sans@0.4.2': {}
+
+  '@expo-google-fonts/dm-serif-display@0.4.2': {}
 
   '@expo-google-fonts/material-symbols@0.4.24': {}
 

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -647,24 +647,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.14':
     resolution: {integrity: sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.14':
     resolution: {integrity: sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.14':
     resolution: {integrity: sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.14':
     resolution: {integrity: sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==}
@@ -1866,66 +1870,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3288,48 +3305,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
@@ -6706,9 +6731,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/mobile/test/setup.ts
+++ b/mobile/test/setup.ts
@@ -726,6 +726,25 @@ vi.mock('@/lib/theme', () => {
     requiredFonts: {},
   };
 
+  const mockPetrolTheme = {
+    id: 'petrol',
+    name: 'Petrol',
+    pickerSwatch: { type: 'color', value: '#0E5C6F' },
+    colors: c,
+    fonts: mockFonts,
+    borderRadius: mockBorderRadius,
+    shadows: mockShadows,
+    buttonDisplay: { display: 'both', wrapper: 'animated', shape: 'circle', interaction: 'scale' },
+    overrides: { checkedOpacity: 0.78, checkboxBorderWidth: 1.5, dashedBorderWidth: 1, cardBorderWidth: 0, cardHighlightBorderWidth: 0, segmentedControlGap: 6, segmentedControlPadding: 4, segmentedControlActiveIndicator: 'underline', chipToggleGap: 8 },
+    visibility: { showStackHeader: true, showTodayDot: true, showTodayBadge: true, showDayNotes: true, showChevrons: true, showStatIcons: true, showProgressBar: true, showAddItemLabel: true, showEmptyStateIcon: true, showHeroOverlay: true, showRecipeActionButtons: true, showVisibilityChip: true, showRecipeTags: true, showFrameLabels: false, showChipToggleDot: true, showStatDividers: false, showSectionHeaderIcon: false, showCheckmarkIndicator: true },
+    chrome: 'full' as const,
+    toggleStyle: 'switch' as const,
+    iconContainerRadius: 0.5,
+    buttonRadius: 9999,
+    tabBar: { borderRadius: 16, borderWidth: 0.5, blur: true, blurIntensity: 40, blurTint: 'light' },
+    requiredFonts: {},
+  };
+
   return {
   spacing: { '2xs': 2, xs: 4, 'xs-sm': 6, sm: 8, 'sm-md': 10, md: 12, 'md-lg': 14, lg: 16, xl: 20, '2xl': 24, '3xl': 32, '4xl': 40 },
   layout: {
@@ -782,10 +801,11 @@ vi.mock('@/lib/theme', () => {
   lightTheme: mockLightTheme,
   terminalTheme: mockTerminalTheme,
   bubblegumTheme: mockBubblegumTheme,
-  themes: { light: mockLightTheme, terminal: mockTerminalTheme, bubblegum: mockBubblegumTheme },
+  petrolTheme: mockPetrolTheme,
+  themes: { light: mockLightTheme, terminal: mockTerminalTheme, bubblegum: mockBubblegumTheme, petrol: mockPetrolTheme },
   defaultThemeId: 'light',
   allRequiredFonts: {},
-  isThemeId: (value: string) => ['light', 'terminal', 'bubblegum'].includes(value),
+  isThemeId: (value: string) => ['light', 'terminal', 'bubblegum', 'petrol'].includes(value),
   };
 });
 

--- a/mobile/test/setup.ts
+++ b/mobile/test/setup.ts
@@ -745,6 +745,8 @@ vi.mock('@/lib/theme', () => {
     requiredFonts: {},
   };
 
+  const themeRegistry = { light: mockLightTheme, terminal: mockTerminalTheme, bubblegum: mockBubblegumTheme, petrol: mockPetrolTheme };
+
   return {
   spacing: { '2xs': 2, xs: 4, 'xs-sm': 6, sm: 8, 'sm-md': 10, md: 12, 'md-lg': 14, lg: 16, xl: 20, '2xl': 24, '3xl': 32, '4xl': 40 },
   layout: {
@@ -802,10 +804,10 @@ vi.mock('@/lib/theme', () => {
   terminalTheme: mockTerminalTheme,
   bubblegumTheme: mockBubblegumTheme,
   petrolTheme: mockPetrolTheme,
-  themes: { light: mockLightTheme, terminal: mockTerminalTheme, bubblegum: mockBubblegumTheme, petrol: mockPetrolTheme },
+  themes: themeRegistry,
   defaultThemeId: 'light',
   allRequiredFonts: {},
-  isThemeId: (value: string) => ['light', 'terminal', 'bubblegum', 'petrol'].includes(value),
+  isThemeId: (value: string) => value in themeRegistry,
   };
 });
 


### PR DESCRIPTION
## Summary

Add a new **Petrol** theme — a modern, editorial-style design built around a deep petrol-blue accent (`#0E5C6F`) on cool paper-white surfaces.

### Design choices

- **Typography**: DM Serif Display for headings (magazine-style display type), DM Sans for body text
- **Palette**: Cool paper-white backgrounds (`#F7F8F8`), ink-dark text (`#11181C`), petrol-blue used sparingly for primary actions, toggles, checkboxes, and AI accent
- **Shape**: Pill-shaped buttons (`buttonRadius: 9999`), generously rounded cards and chips, circular icon containers
- **Cards**: Borderless — depth from quiet layered cool-ink shadows only
- **Chips/Meta**: Unified soft ink wash (`4% opacity`), no visible borders — clean and cohesive
- **Action buttons**: Tinted petrol-glass backgrounds so icon buttons read as actual controls against white cards
- **Tab bar**: Floating glass (consistent with Elegant), petrol-tinted active state
- **Segmented control**: Underline active indicator (matches editorial tab-row style)

### Files changed

| File | Purpose |
|------|---------|
| `mobile/lib/theme/petrol-colors.ts` | Full `ColorTokens` palette |
| `mobile/lib/theme/themes/petrol.ts` | `ThemeDefinition` with serif fonts, pill radii, shadows |
| `mobile/lib/theme/themes/index.ts` | Register petrol in theme registry |
| `mobile/test/setup.ts` | Add mock theme for tests |
| `mobile/package.json` / `pnpm-lock.yaml` | Add `@expo-google-fonts/dm-serif-display` |

### Testing

- All 819 mobile tests pass
- All pre-commit hooks pass (TypeScript, Biome, Prettier)
- Manually tested in web browser — theme picker, recipe detail, meal plan, grocery list
