### PR TITLE
feat(mobile): home/grocery/recipe detail visual polish + petrol ink softening

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -177,6 +177,7 @@ const Header = ({
             size={44}
             iconSize={24}
             color={colors.border}
+            textColor={colors.accent}
             style={shadows.sm}
           />
         )}

--- a/mobile/components/GroceryListView.tsx
+++ b/mobile/components/GroceryListView.tsx
@@ -287,6 +287,7 @@ export const GroceryListView = ({
       style={{ flex: 1 }}
       contentContainerStyle={{
         paddingHorizontal: spacing.xl,
+        paddingTop: spacing.md,
         paddingBottom: layout.tabBar.contentBottomPadding,
       }}
       showsVerticalScrollIndicator={false}

--- a/mobile/components/grocery/StoreChips.tsx
+++ b/mobile/components/grocery/StoreChips.tsx
@@ -24,6 +24,7 @@ export const StoreChips = ({
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
+      style={{ marginBottom: spacing.md }}
       contentContainerStyle={{ gap: spacing.xs, paddingVertical: spacing.xs }}
     >
       <FilterChip

--- a/mobile/components/home/StatsCards.tsx
+++ b/mobile/components/home/StatsCards.tsx
@@ -118,40 +118,53 @@ const StatCard = ({
         flex: 1,
         backgroundColor: colors.statsCard.bg,
         borderRadius: borderRadius.md,
-        padding: 12,
+        paddingVertical: spacing.sm,
+        paddingHorizontal: spacing.sm,
         borderWidth: 1,
         borderColor: colors.statsCard.borderColor,
+        alignItems: 'center',
         ...shadows.sm,
       }}
     >
       {visibility.showStatIcons && (
         <ThemeIcon
           name={icon}
-          size={18}
+          size={16}
           color={iconColor}
-          style={{ marginBottom: 8 }}
+          style={{ marginBottom: spacing['2xs'] }}
         />
       )}
-      <Text
+      <View
         style={{
-          fontSize: fontSize['3xl'],
-          fontFamily: fonts.bodySemibold,
-          color: colors.content.body,
-          letterSpacing: letterSpacing.tight,
+          flexDirection: 'row',
+          alignItems: 'baseline',
+          gap: spacing['2xs'],
         }}
       >
-        {value}
-      </Text>
-      <Text
-        style={{
-          fontSize: fontSize.xs,
-          fontFamily: fonts.body,
-          color: subtitle ? colors.content.secondary : 'transparent',
-          marginBottom: 2,
-        }}
-      >
-        {subtitle || ' '}
-      </Text>
+        <Text
+          style={{
+            fontSize: fontSize['2xl'],
+            fontFamily: fonts.bodySemibold,
+            color: colors.content.body,
+            letterSpacing: letterSpacing.tight,
+          }}
+          numberOfLines={1}
+        >
+          {value}
+        </Text>
+        {subtitle && (
+          <Text
+            style={{
+              fontSize: fontSize.xs,
+              fontFamily: fonts.body,
+              color: colors.content.secondary,
+            }}
+            numberOfLines={1}
+          >
+            {subtitle}
+          </Text>
+        )}
+      </View>
       <Text
         style={{
           fontSize: fontSize.xs,
@@ -159,7 +172,9 @@ const StatCard = ({
           color: colors.content.secondary,
           letterSpacing: letterSpacing.wide,
           textTransform: 'uppercase',
+          marginTop: 2,
         }}
+        numberOfLines={1}
       >
         {label}
       </Text>

--- a/mobile/components/home/StatsCards.tsx
+++ b/mobile/components/home/StatsCards.tsx
@@ -172,7 +172,7 @@ const StatCard = ({
           color: colors.content.secondary,
           letterSpacing: letterSpacing.wide,
           textTransform: 'uppercase',
-          marginTop: 2,
+          marginTop: spacing['2xs'],
         }}
         numberOfLines={1}
       >

--- a/mobile/components/meal-plan/RecipeRow.tsx
+++ b/mobile/components/meal-plan/RecipeRow.tsx
@@ -22,7 +22,7 @@ export const RecipeRow = ({
   onPress,
   onRemove,
 }: RecipeRowProps) => {
-  const { colors, fonts, borderRadius } = useTheme();
+  const { colors, fonts, borderRadius, shadows } = useTheme();
   const resolvedImage = imageUrl || PLACEHOLDER_IMAGE;
 
   return (
@@ -34,6 +34,7 @@ export const RecipeRow = ({
         borderRadius: borderRadius.sm,
         padding: spacing.md,
         marginBottom: spacing['xs-sm'],
+        ...shadows.card,
       }}
     >
       <Pressable

--- a/mobile/components/recipe-detail/RecipeActionButtons.tsx
+++ b/mobile/components/recipe-detail/RecipeActionButtons.tsx
@@ -63,9 +63,7 @@ export const RecipeActionButtons = ({
 }: RecipeActionButtonsProps) => {
   const { visibility, colors, fonts, shadows } = useTheme();
   const { width } = useWindowDimensions();
-  // On narrow screens (phones), labels get truncated and look ugly with
-  // ellipsis dots — collapse to icon-only pills below this breakpoint.
-  const compact = width < 480;
+  const compact = width < COMPACT_BREAKPOINT;
   if (!visibility.showRecipeActionButtons) return null;
   const enhanceDisabled = isEnhancing || !aiEnabled || !isOwned;
 
@@ -194,3 +192,6 @@ const compactPillStyle: ViewStyle = {
   paddingHorizontal: spacing.xs,
   gap: 0,
 };
+
+/** Below this width, action pills collapse to icon-only (no labels). */
+const COMPACT_BREAKPOINT = 480;

--- a/mobile/components/recipe-detail/RecipeActionButtons.tsx
+++ b/mobile/components/recipe-detail/RecipeActionButtons.tsx
@@ -1,4 +1,10 @@
-import { Pressable, Text, View, type ViewStyle } from 'react-native';
+import {
+  Pressable,
+  Text,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from 'react-native';
 import { ThemeIcon } from '@/components/ThemeIcon';
 import { showAlert } from '@/lib/alert';
 import type { TFunction } from '@/lib/i18n';
@@ -56,6 +62,10 @@ export const RecipeActionButtons = ({
   onToggleKeepScreenOn,
 }: RecipeActionButtonsProps) => {
   const { visibility, colors, fonts, shadows } = useTheme();
+  const { width } = useWindowDimensions();
+  // On narrow screens (phones), labels get truncated and look ugly with
+  // ellipsis dots — collapse to icon-only pills below this breakpoint.
+  const compact = width < 480;
   if (!visibility.showRecipeActionButtons) return null;
   const enhanceDisabled = isEnhancing || !aiEnabled || !isOwned;
 
@@ -131,6 +141,7 @@ export const RecipeActionButtons = ({
             accessibilityLabel={tile.label}
             style={({ pressed }) => [
               pillStyle,
+              compact ? compactPillStyle : null,
               shadows.sm,
               {
                 backgroundColor:
@@ -140,17 +151,19 @@ export const RecipeActionButtons = ({
             ]}
           >
             <ThemeIcon name={tile.icon as never} size={18} color={fg} />
-            <Text
-              numberOfLines={1}
-              style={{
-                fontSize: fontSize.md,
-                fontFamily: fonts.bodyMedium,
-                color: fg,
-                letterSpacing: letterSpacing.normal,
-              }}
-            >
-              {tile.label}
-            </Text>
+            {!compact && (
+              <Text
+                numberOfLines={1}
+                style={{
+                  fontSize: fontSize.md,
+                  fontFamily: fonts.bodyMedium,
+                  color: fg,
+                  letterSpacing: letterSpacing.normal,
+                }}
+              >
+                {tile.label}
+              </Text>
+            )}
           </Pressable>
         );
       })}
@@ -175,4 +188,9 @@ const pillStyle: ViewStyle = {
   paddingVertical: spacing.md,
   paddingHorizontal: spacing.sm,
   borderRadius: borderRadius.full,
+};
+
+const compactPillStyle: ViewStyle = {
+  paddingHorizontal: spacing.xs,
+  gap: 0,
 };

--- a/mobile/components/recipe-detail/RecipeTimeServings.tsx
+++ b/mobile/components/recipe-detail/RecipeTimeServings.tsx
@@ -92,7 +92,8 @@ const ServingsInteractive = ({
           onPress={onDecrement}
           disabled={decrementDisabled}
           tone="alt"
-          size="sm"
+          size={26}
+          iconSize={14}
           label={t('recipe.decreasePortions')}
         />
         <Pressable
@@ -121,7 +122,8 @@ const ServingsInteractive = ({
           icon="add"
           onPress={onIncrement}
           tone="alt"
-          size="sm"
+          size={26}
+          iconSize={14}
           label={t('recipe.increasePortions')}
         />
       </View>

--- a/mobile/components/recipe-detail/RecipeTimeServings.tsx
+++ b/mobile/components/recipe-detail/RecipeTimeServings.tsx
@@ -94,6 +94,7 @@ const ServingsInteractive = ({
           tone="alt"
           size={26}
           iconSize={14}
+          hitSlop={9}
           label={t('recipe.decreasePortions')}
         />
         <Pressable
@@ -124,6 +125,7 @@ const ServingsInteractive = ({
           tone="alt"
           size={26}
           iconSize={14}
+          hitSlop={9}
           label={t('recipe.increasePortions')}
         />
       </View>

--- a/mobile/lib/theme/petrol-colors.ts
+++ b/mobile/lib/theme/petrol-colors.ts
@@ -27,9 +27,9 @@ const PAPER_LIGHT = '#FCFCFC';
 const PAPER_MID = '#F1F2F3';
 const PAPER_DEEP = '#E7E9EA';
 
-/** Ink — near-black with a faint cool cast for headings/body. */
-const INK = '#11181C';
-const INK_BODY = '#1F2A2E';
+/** Ink — dark grey with a faint cool cast for headings/body. */
+const INK = '#2C3539';
+const INK_BODY = '#3A464B';
 const INK_MUTED = '#5A6A6E';
 const INK_SOFT = '#8A969A';
 const INK_FAINT = '#B7BFC2';


### PR DESCRIPTION
## Summary

Visual polish for home, grocery, meal-plan, and recipe detail screens.

### Home
- **Stats cards**: Compact layout — smaller icon (16px), value (2xl), tighter padding, subtitle inline next to percentage instead of wasting a row
- **Settings gear**: Icon glyph now petrol-colored (was invisible grey)

### Grocery
- **Store chips**: Added spacing below chips before the stats card
- **Items list**: Added top padding before the item list starts

### Meal Plan
- **Recipe rows**: Added `shadows.card` so each meal row has subtle elevation matching grocery items

### Recipe Detail
- **Portion buttons**: Shrunk +/- from 32px to 26px so they don't dominate on narrow phones
- **Action toolbar**: Icon-only pills below 480px width — no more truncated labels with ellipsis dots

### Petrol Theme
- **Softer ink**: Headings and body text changed from near-black (#11181C/#1F2A2E) to dark grey (#2C3539/#3A464B) — all derived tokens cascade automatically
