### PR TITLE
refactor: unify typography scale, petrol palette, and Button usage

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -3,12 +3,13 @@ import { HomeScreenSkeleton, IconButton, ScreenLayout } from '@/components';
 import { HeroNextMeal } from '@/components/home/HeroNextMeal';
 import { InspirationSection } from '@/components/home/InspirationSection';
 import { WeekStrip } from '@/components/home/WeekStrip';
+import { ScreenTitle } from '@/components/ScreenTitle';
 import { hapticLight } from '@/lib/haptics';
 import { useHomeScreenData } from '@/lib/hooks/useHomeScreenData';
 import { layout, spacing, useTheme } from '@/lib/theme';
 
 export default function HomeScreen() {
-  const { colors } = useTheme();
+  const { colors, shadows } = useTheme();
   const {
     router,
     recipes,
@@ -48,19 +49,51 @@ export default function HomeScreen() {
         }
         showsVerticalScrollIndicator={false}
       >
-        <TopBar
-          onAdd={() => {
-            hapticLight();
-            router.push({
-              pathname: '/(tabs)/recipes',
-              params: { addRecipe: 'true' },
-            });
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingHorizontal: spacing.xl,
+            paddingBottom: spacing.lg,
           }}
-          onSettings={() => {
-            hapticLight();
-            router.push('/settings');
-          }}
-        />
+        >
+          <ScreenTitle
+            title={t('signIn.appName')}
+            subtitle={t('home.subtitle')}
+            variant="large"
+            style={{ flex: 1 }}
+          />
+          <View style={{ flexDirection: 'row', gap: spacing.sm }}>
+            <IconButton
+              onPress={() => {
+                hapticLight();
+                router.push({
+                  pathname: '/(tabs)/recipes',
+                  params: { addRecipe: 'true' },
+                });
+              }}
+              icon="add"
+              size={40}
+              iconSize={20}
+              color={colors.card.bg}
+              textColor={colors.content.body}
+              style={shadows.sm}
+            />
+            <IconButton
+              onPress={() => {
+                hapticLight();
+                router.push('/settings');
+              }}
+              icon="settings-outline"
+              size={40}
+              iconSize={20}
+              color={colors.card.bg}
+              textColor={colors.content.body}
+              style={shadows.sm}
+            />
+          </View>
+        </View>
 
         <HeroNextMeal
           nextMeal={nextMeal}
@@ -84,53 +117,3 @@ export default function HomeScreen() {
     </ScreenLayout>
   );
 }
-
-/**
- * Bare top bar with the only two header actions: add recipe + settings.
- * No greeting, no title — the hero IS the title.
- *
- * The buttons share the same opaque-white-card + sm-shadow language as
- * the floating "Open" / "Shuffle" pills on the hero and inspiration
- * cards, so the whole tab feels like one editorial surface instead of
- * three different icon styles.
- */
-const TopBar = ({
-  onAdd,
-  onSettings,
-}: {
-  onAdd: () => void;
-  onSettings: () => void;
-}) => {
-  const { colors, shadows } = useTheme();
-  return (
-    <View
-      style={{
-        flexDirection: 'row',
-        justifyContent: 'flex-end',
-        alignItems: 'center',
-        gap: spacing.sm,
-        paddingHorizontal: spacing.xl,
-        paddingBottom: spacing.lg,
-      }}
-    >
-      <IconButton
-        onPress={onAdd}
-        icon="add"
-        size={44}
-        iconSize={22}
-        color={colors.card.bg}
-        textColor={colors.content.body}
-        style={shadows.sm}
-      />
-      <IconButton
-        onPress={onSettings}
-        icon="settings-outline"
-        size={44}
-        iconSize={22}
-        color={colors.card.bg}
-        textColor={colors.content.body}
-        style={shadows.sm}
-      />
-    </View>
-  );
-};

--- a/mobile/components/BottomSheetModal.tsx
+++ b/mobile/components/BottomSheetModal.tsx
@@ -98,7 +98,7 @@ export const BottomSheetModal = ({
       >
         <Text
           style={{
-            fontSize: fontSize['3xl'],
+            fontSize: fontSize['xl-2xl'],
             fontFamily: fonts.display,
             letterSpacing: letterSpacing.tight,
             color: colors.content.heading,
@@ -124,7 +124,7 @@ export const BottomSheetModal = ({
       {subtitle && (
         <Text
           style={{
-            fontSize: fontSize.md,
+            fontSize: fontSize.base,
             fontFamily: fonts.body,
             color: colors.content.tertiary,
             paddingHorizontal: spacing.xl,

--- a/mobile/components/GroceryItemRow.tsx
+++ b/mobile/components/GroceryItemRow.tsx
@@ -155,7 +155,7 @@ export const GroceryItemRow = ({
         <View style={{ flex: 1 }}>
           <Text
             style={{
-              fontSize: fontSize.xl,
+              fontSize: fontSize.lg,
               fontFamily: fonts.bodyMedium,
               fontWeight: fontWeight.medium,
               textDecorationLine: checked ? 'line-through' : 'none',
@@ -169,7 +169,7 @@ export const GroceryItemRow = ({
           {item.recipe_sources.length > 0 && (
             <Text
               style={{
-                fontSize: fontSize.base,
+                fontSize: fontSize.sm,
                 fontFamily: fonts.body,
                 color: checked
                   ? colors.listItem.checkedText

--- a/mobile/components/RecipeCard.tsx
+++ b/mobile/components/RecipeCard.tsx
@@ -233,7 +233,7 @@ export const RecipeCard = ({
           <View style={{ flex: 1, marginLeft: spacing.lg }}>
             <Text
               style={{
-                fontSize: fontSize['lg-xl'],
+                fontSize: fontSize.lg,
                 fontFamily: fonts.bodyMedium,
                 color: colors.content.heading,
                 letterSpacing: letterSpacing.normal,
@@ -659,8 +659,7 @@ export const RecipeCard = ({
             <Text
               style={{
                 fontSize: fontSize.md,
-                fontFamily: fonts.bodySemibold,
-                fontWeight: fontWeight.semibold,
+                fontFamily: fonts.bodyMedium,
                 color: colors.content.heading,
                 lineHeight: lineHeight.sm,
               }}

--- a/mobile/components/ScreenTitle.tsx
+++ b/mobile/components/ScreenTitle.tsx
@@ -77,23 +77,23 @@ export const ScreenTitle = ({
 
 const styles = StyleSheet.create({
   centeredTitle: {
-    fontSize: fontSize['3xl'],
+    fontSize: fontSize['xl-2xl'],
     fontWeight: fontWeight.bold,
     letterSpacing: letterSpacing.tight,
     textAlign: 'center',
   },
   centeredSubtitle: {
-    fontSize: fontSize.md,
+    fontSize: fontSize.base,
     marginTop: spacing['2xs'],
     textAlign: 'center',
   },
   largeTitle: {
-    fontSize: fontSize['4xl'],
+    fontSize: fontSize['3xl'],
     letterSpacing: letterSpacing.tight,
     textAlign: 'center',
   },
   largeSubtitle: {
-    fontSize: fontSize.lg,
+    fontSize: fontSize.base,
     letterSpacing: letterSpacing.normal,
     marginTop: spacing.xs,
     textAlign: 'center',

--- a/mobile/components/grocery/EmptyGroceryState.tsx
+++ b/mobile/components/grocery/EmptyGroceryState.tsx
@@ -52,7 +52,7 @@ export const EmptyGroceryState = ({
       <Text
         style={{
           color: colors.content.body,
-          fontSize: fontSize['xl-2xl'],
+          fontSize: fontSize.xl,
           fontFamily: fonts.bodySemibold,
           textAlign: 'center',
         }}
@@ -62,7 +62,7 @@ export const EmptyGroceryState = ({
       <Text
         style={{
           color: colors.content.tertiary,
-          fontSize: fontSize.xl,
+          fontSize: fontSize.base,
           marginTop: spacing.sm,
           textAlign: 'center',
           lineHeight: lineHeight.lg,

--- a/mobile/components/home/HeroNextMeal.tsx
+++ b/mobile/components/home/HeroNextMeal.tsx
@@ -136,8 +136,8 @@ export const HeroNextMeal = ({ nextMeal, t, onPress }: HeroNextMealProps) => {
           <Text
             style={{
               fontFamily: fonts.displayBold,
-              fontSize: fontSize['4xl'],
-              lineHeight: 36,
+              fontSize: fontSize['3xl'],
+              lineHeight: 30,
               color: colors.white,
               letterSpacing: letterSpacing.tight,
             }}

--- a/mobile/components/meal-plan/DayHeader.tsx
+++ b/mobile/components/meal-plan/DayHeader.tsx
@@ -91,8 +91,8 @@ export const DayHeader = ({
           )}
           <Text
             style={{
-              fontSize: fontSize.xl,
-              fontFamily: fonts.bodySemibold,
+              fontSize: fontSize.lg,
+              fontFamily: fonts.bodyMedium,
               color: isToday ? colors.primary : colors.content.headingMuted,
               letterSpacing: letterSpacing.normal,
             }}

--- a/mobile/components/meal-plan/WeekSelector.tsx
+++ b/mobile/components/meal-plan/WeekSelector.tsx
@@ -48,10 +48,9 @@ export const WeekSelector = ({
         <View style={{ alignItems: 'center' }}>
           <Text
             style={{
-              fontSize: fontSize.md,
-              fontFamily: fonts.bodySemibold,
-              fontWeight: fontWeight.semibold,
-              color: colors.content.strong,
+              fontSize: fontSize.base,
+              fontFamily: fonts.body,
+              color: colors.content.subtitle,
             }}
           >
             {formatWeekRange(weekDates, language)}

--- a/mobile/components/recipe-detail/InstructionItem.tsx
+++ b/mobile/components/recipe-detail/InstructionItem.tsx
@@ -183,7 +183,7 @@ export const InstructionItem = ({
         )}
         <Text
           style={{
-            fontSize: fontSize.xl,
+            fontSize: fontSize.lg,
             fontFamily: fonts.body,
             color: isCompleted
               ? colors.timeline.completedText

--- a/mobile/components/recipe-detail/RecipeActionButtons.tsx
+++ b/mobile/components/recipe-detail/RecipeActionButtons.tsx
@@ -1,16 +1,10 @@
-import { Text, View, type ViewStyle } from 'react-native';
-import { AnimatedPressable } from '@/components/AnimatedPressable';
+import { View, type ViewStyle } from 'react-native';
+import type { ButtonTone } from '@/components/Button';
+import { Button } from '@/components/Button';
 import type { IoniconName } from '@/components/ThemeIcon';
-import { ThemeIcon } from '@/components/ThemeIcon';
 import { showAlert } from '@/lib/alert';
 import type { TFunction } from '@/lib/i18n';
-import {
-  borderRadius,
-  fontSize,
-  letterSpacing,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { spacing, useTheme } from '@/lib/theme';
 
 interface RecipeActionButtonsProps {
   canEdit: boolean;
@@ -34,8 +28,8 @@ interface ActionTile {
   icon: IoniconName;
   label: string;
   onPress: () => void;
-  /** Use the AI accent fg instead of the regular content color. */
-  accentAi?: boolean;
+  /** Tone override — defaults to "glass". Use "glassAi" for AI-accented actions. */
+  tone?: ButtonTone;
   disabled?: boolean;
   dimmed?: boolean;
 }
@@ -56,7 +50,7 @@ export const RecipeActionButtons = ({
   onEnhance,
   onToggleKeepScreenOn,
 }: RecipeActionButtonsProps) => {
-  const { visibility, colors, fonts, shadows } = useTheme();
+  const { visibility } = useTheme();
   if (!visibility.showRecipeActionButtons) return null;
   const enhanceDisabled = isEnhancing || !aiEnabled || !isOwned;
 
@@ -101,7 +95,7 @@ export const RecipeActionButtons = ({
             key: 'enhance',
             icon: 'sparkles' as IoniconName,
             label: t('recipe.enhance'),
-            accentAi: true,
+            tone: 'glassAi' as const,
             disabled: enhanceDisabled,
             dimmed: enhanceDisabled,
             onPress: onEnhance,
@@ -118,43 +112,23 @@ export const RecipeActionButtons = ({
 
   return (
     <View style={rowStyle}>
-      {tiles.map((tile) => {
-        const fg = tile.accentAi
-          ? colors.tones.glassAi.fg
-          : colors.content.body;
-        return (
-          <AnimatedPressable
-            key={tile.key}
-            onPress={tile.onPress}
-            disabled={tile.disabled}
-            accessibilityRole="button"
-            accessibilityLabel={tile.label}
-            hoverScale={1.02}
-            pressScale={0.97}
-            style={{
-              ...tileStyle,
-              backgroundColor: colors.card.bg,
-              ...shadows.sm,
-              ...(tile.dimmed ? { opacity: 0.5 } : null),
-            }}
-          >
-            <ThemeIcon name={tile.icon} size={22} color={fg} />
-            <Text
-              numberOfLines={1}
-              style={{
-                fontFamily: fonts.bodySemibold,
-                fontSize: fontSize.xs,
-                color: fg,
-                letterSpacing: letterSpacing.wide,
-                textTransform: 'uppercase',
-                marginTop: spacing.xs,
-              }}
-            >
-              {tile.label}
-            </Text>
-          </AnimatedPressable>
-        );
-      })}
+      {tiles.map((tile) => (
+        <Button
+          key={tile.key}
+          variant="primary"
+          size="sm"
+          tone={tile.tone ?? 'glass'}
+          icon={tile.icon}
+          label={tile.label}
+          onPress={tile.onPress}
+          disabled={tile.disabled}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            ...(tile.dimmed ? { opacity: 0.5 } : null),
+          }}
+        />
+      ))}
     </View>
   );
 };
@@ -164,14 +138,5 @@ const rowStyle: ViewStyle = {
   alignItems: 'stretch',
   gap: spacing.sm,
   width: '100%',
-};
-
-const tileStyle: ViewStyle = {
-  flex: 1,
-  minWidth: 0,
-  alignItems: 'center',
-  justifyContent: 'center',
-  paddingVertical: spacing.md,
-  paddingHorizontal: spacing.xs,
-  borderRadius: borderRadius.md,
+  flexWrap: 'wrap',
 };

--- a/mobile/lib/theme/colors.ts
+++ b/mobile/lib/theme/colors.ts
@@ -357,21 +357,21 @@ export const lightColors = {
   primaryDark: '#1A1A1A',
   primaryLight: '#404040',
 
-  // Background gradients - warm cream/linen tones
-  bgBase: '#EDE4DA',
-  bgLight: '#FAF5EF',
-  bgMid: '#F0E4D8',
-  bgDark: '#E5D5C5',
-  bgWarm: '#F8EDE2',
+  // Background gradients - cool petrol / glacier tones
+  bgBase: '#DCE7EC',
+  bgLight: '#EEF4F6',
+  bgMid: '#C9DAE1',
+  bgDark: '#A8C0CA',
+  bgWarm: '#E2ECF0',
 
-  // Accent colors - Warm terracotta/burnt orange
-  accent: '#D4845A',
-  accentDark: '#C07548',
-  accentLight: '#F0C4A8',
-  coral: '#E0855A',
-  coralSoft: '#F0A888',
-  gold: '#C4A060',
-  goldLight: '#E8D5A3',
+  // Accent colors - Deep petrol
+  accent: '#2C5664',
+  accentDark: '#1F4250',
+  accentLight: '#7BA0AE',
+  coral: '#3D6E7E',
+  coralSoft: '#9CBAC5',
+  gold: '#7E8C5A',
+  goldLight: '#C8D2B0',
 
   // Category colors (luxurious pastels)
   category: {
@@ -403,65 +403,65 @@ export const lightColors = {
     },
   },
 
-  // Neutrals - refined gray scale with warmth
+  // Neutrals - cool slate scale
   white: '#FFFFFF',
-  offWhite: '#FAFAFA',
+  offWhite: '#F8FAFB',
   text: {
-    primary: '#5D4E40',
-    secondary: 'rgba(93, 78, 64, 0.7)',
-    muted: 'rgba(93, 78, 64, 0.5)',
-    light: 'rgba(93, 78, 64, 0.35)',
-    inverse: '#2D2D2D',
-    dark: '#5D4E40',
+    primary: '#2E444C',
+    secondary: 'rgba(46, 68, 76, 0.7)',
+    muted: 'rgba(46, 68, 76, 0.5)',
+    light: 'rgba(46, 68, 76, 0.35)',
+    inverse: '#1A2429',
+    dark: '#2E444C',
   },
-  border: 'rgba(93, 78, 64, 0.18)',
-  borderLight: 'rgba(93, 78, 64, 0.1)',
-  borderFaint: 'rgba(93, 78, 64, 0.04)',
+  border: 'rgba(46, 68, 76, 0.18)',
+  borderLight: 'rgba(46, 68, 76, 0.1)',
+  borderFaint: 'rgba(46, 68, 76, 0.04)',
 
-  // Content colors — dark text/icons on light backgrounds (warm brown family)
+  // Content colors — dark text/icons on light backgrounds (cool slate family)
   content: {
-    heading: '#5D4E40',
-    headingMuted: 'rgba(93, 78, 64, 0.75)',
-    headingWarm: '#4A3728',
-    body: '#5D4E40',
-    secondary: '#8B7355',
-    strong: 'rgba(93, 78, 64, 0.8)',
-    tertiary: 'rgba(93, 78, 64, 0.7)',
-    subtitle: 'rgba(93, 78, 64, 0.6)',
-    icon: 'rgba(93, 78, 64, 0.5)',
-    placeholder: 'rgba(93, 78, 64, 0.4)',
-    placeholderHex: '#8B735580',
+    heading: '#2E444C',
+    headingMuted: 'rgba(46, 68, 76, 0.75)',
+    headingWarm: '#1F3742',
+    body: '#2E444C',
+    secondary: '#52707C',
+    strong: 'rgba(46, 68, 76, 0.8)',
+    tertiary: 'rgba(46, 68, 76, 0.7)',
+    subtitle: 'rgba(46, 68, 76, 0.6)',
+    icon: 'rgba(46, 68, 76, 0.5)',
+    placeholder: 'rgba(46, 68, 76, 0.4)',
+    placeholderHex: '#52707C80',
   },
 
-  // Interactive surface states — warm brown at various opacities
+  // Interactive surface states — cool slate at various opacities
   surface: {
-    overlay: 'rgba(93, 78, 64, 0.85)',
-    overlayMedium: 'rgba(93, 78, 64, 0.75)',
-    border: 'rgba(93, 78, 64, 0.18)',
-    borderLight: 'rgba(93, 78, 64, 0.12)',
-    divider: 'rgba(93, 78, 64, 0.12)',
-    dividerSolid: '#DDD0C2',
-    modal: '#F2EAE0',
-    pressed: 'rgba(93, 78, 64, 0.12)',
-    active: 'rgba(93, 78, 64, 0.08)',
-    subtle: 'rgba(93, 78, 64, 0.06)',
-    hover: 'rgba(93, 78, 64, 0.05)',
-    tint: 'rgba(93, 78, 64, 0.04)',
-    sheetOverlay: 'rgba(235, 232, 228, 0.94)',
-    iconBg: 'rgba(139, 115, 85, 0.1)',
+    overlay: 'rgba(46, 68, 76, 0.85)',
+    overlayMedium: 'rgba(46, 68, 76, 0.75)',
+    border: 'rgba(46, 68, 76, 0.18)',
+    borderLight: 'rgba(46, 68, 76, 0.12)',
+    divider: 'rgba(46, 68, 76, 0.12)',
+    dividerSolid: '#C2D0D6',
+    modal: '#EAF1F4',
+    pressed: 'rgba(46, 68, 76, 0.12)',
+    active: 'rgba(46, 68, 76, 0.08)',
+    subtle: 'rgba(46, 68, 76, 0.06)',
+    hover: 'rgba(46, 68, 76, 0.05)',
+    tint: 'rgba(46, 68, 76, 0.04)',
+    sheetOverlay: 'rgba(228, 236, 240, 0.94)',
+    iconBg: 'rgba(82, 112, 124, 0.1)',
   },
 
-  // Button colors — warm vivid orange
+  // Button colors — deep petrol
   button: {
-    primary: '#D97A45',
-    primaryPressed: '#C06B38',
+    primary: '#2C5664',
+    primaryPressed: '#1F4250',
     primaryText: '#FFFFFF',
-    disabled: '#C5B8A8',
-    primarySubtle: 'rgba(217, 122, 69, 0.08)',
-    primarySurface: 'rgba(217, 122, 69, 0.1)',
-    primaryActive: 'rgba(217, 122, 69, 0.14)',
-    primaryHover: 'rgba(217, 122, 69, 0.18)',
-    primaryDivider: 'rgba(217, 122, 69, 0.22)',
+    disabled: '#A8BCC4',
+    primarySubtle: 'rgba(44, 86, 100, 0.08)',
+    primarySurface: 'rgba(44, 86, 100, 0.1)',
+    primaryActive: 'rgba(44, 86, 100, 0.14)',
+    primaryHover: 'rgba(44, 86, 100, 0.18)',
+    primaryDivider: 'rgba(44, 86, 100, 0.22)',
   },
 
   // Refined gray scale
@@ -601,26 +601,26 @@ export const lightColors = {
     text: 'rgba(180, 80, 70, 0.9)',
   },
 
-  // Gradient decorative — animated background orbs and gradient stops
+  // Gradient decorative — animated background orbs and gradient stops (cold petrol palette)
   gradient: {
-    orb1: '#EEDACC',
-    orb2: '#E0C4AE',
-    orb3: '#D5C4B6',
-    orb4: '#7A726A',
-    orb5: '#EADAC8',
-    orb6: '#8A827A',
-    stop1: '#D8BCA6',
-    stop2: '#E6D0BC',
+    orb1: '#E0EBEF',
+    orb2: '#B8CED6',
+    orb3: '#CEDCE2',
+    orb4: '#5C7E8A',
+    orb5: '#D6E2E7',
+    orb6: '#7B98A4',
+    stop1: '#A2BCC6',
+    stop2: '#D2DFE4',
   },
 
   // Background overlays — used by GradientBackground to tint/cover the base image
   background: {
-    mutedOverlay: 'rgba(0, 0, 0, 0.12)',
-    defaultOverlay: 'rgba(255, 255, 255, 0.06)',
-    structuredWash: 'rgba(240, 234, 226, 0.96)',
-    structuredGradientStart: 'rgba(220, 212, 202, 0.12)',
+    mutedOverlay: 'rgba(20, 40, 50, 0.12)',
+    defaultOverlay: 'rgba(255, 255, 255, 0.05)',
+    structuredWash: 'rgba(220, 231, 236, 0.96)',
+    structuredGradientStart: 'rgba(162, 188, 198, 0.16)',
     structuredGradientEnd: 'transparent',
-    animatedOverlay: 'rgba(255, 255, 255, 0.06)',
+    animatedOverlay: 'rgba(255, 255, 255, 0.05)',
   },
 
   // Tag dot colors — muted palette for note/suggestion tags


### PR DESCRIPTION
## Summary

Unify typography sizes, shift to cold petrol color palette, and refactor action buttons to use shared Button component.

## Changes

### Typography normalization
- **ScreenTitle**: centered 24→22, large 28→24; subtitles unified to `fontSize.base` (14) across all pages
- **List items**: `fontSize.lg` / `bodyMedium` across RecipeCard, GroceryItemRow, DayHeader, InstructionItem
- **Modals**: title 24→22, subtitle 15→14
- **EmptyGroceryState**: title 22→18, subtitle 18→14
- **HeroNextMeal**: title 28→24
- **WeekSelector**: week range text normalized to subtitle style
- **RecipeCard grid**: `bodySemibold+semibold` → `bodyMedium` (less bold)

### Color palette shift
- Full light theme palette shifted from warm cream/terracotta to cold petrol tones
- Affects: bgBase, gradient orbs, text/border/surface, accent, buttons

### Component refactors
- **RecipeActionButtons**: inline AnimatedPressable tiles → shared `Button` component (`variant="primary"`, `tone="glass"/"glassAi"`)
- **Home screen**: added ScreenTitle (variant="large") + IconButtons in same row, no header bar background

## Testing
- All 819 mobile tests passing
- Biome lint clean
- TypeScript clean