### PR TITLE
style(mobile): tighten type and spacing scale

### DIFF
--- a/mobile/lib/theme/layout.ts
+++ b/mobile/lib/theme/layout.ts
@@ -2,12 +2,12 @@
  * Spacing, layout, border radius, icon sizes, shadows, and animation constants.
  */
 
-// Spacing scale — modernized in Phase 2 of the design-system refresh.
-// Values snap to a 4-based ramp with a 2px hairline accent at the bottom
-// (2/4/8/12/16/24/32/40/48). Half-step keys (`xs-sm`, `sm-md`, `md-lg`,
-// `lg-xl`) are preserved to avoid touching the ~100 consumer call sites,
-// but their values now collapse to the nearest 4-step neighbour for a
-// tighter, more consistent rhythm across all themes.
+// Spacing scale — tightened for a more compact, harmonious rhythm.
+// Values follow a 2-based ramp at the small end (2/4/6/8/10/12/14/16) and
+// step up in larger increments above 16 (20/28/36/44). Half-step keys
+// (`xs-sm`, `sm-md`, `md-lg`) are preserved to avoid touching the ~100
+// consumer call sites and now sit between their neighbours (6/10/14) for a
+// finer, less spongy spacing rhythm across all themes.
 export const spacing = {
   '2xs': 2,
   xs: 4,

--- a/mobile/lib/theme/layout.ts
+++ b/mobile/lib/theme/layout.ts
@@ -11,16 +11,16 @@
 export const spacing = {
   '2xs': 2,
   xs: 4,
-  'xs-sm': 8,
+  'xs-sm': 6,
   sm: 8,
-  'sm-md': 12,
+  'sm-md': 10,
   md: 12,
-  'md-lg': 16,
+  'md-lg': 14,
   lg: 16,
-  xl: 24,
-  '2xl': 32,
-  '3xl': 40,
-  '4xl': 48,
+  xl: 20,
+  '2xl': 28,
+  '3xl': 36,
+  '4xl': 44,
 } as const;
 
 // Layout constants
@@ -32,12 +32,12 @@ export const layout = {
     alignSelf: 'center' as const,
     width: '100%' as const,
   },
-  screenPaddingTop: 48,
-  screenPaddingHorizontal: 24,
+  screenPaddingTop: 32,
+  screenPaddingHorizontal: 20,
   /** Vertical breathing room between sibling sections on a screen.
    *  Single source of truth — replaces ad-hoc `spacing.lg`/`xl`/`2xl` between blocks. */
-  sectionGap: 32,
-  cardGap: 8,
+  sectionGap: 24,
+  cardGap: 6,
   /** @deprecated Use layout.tabBar instead */
   tabBarHeight: 88,
   tabBar: {
@@ -91,13 +91,13 @@ export interface BorderRadiusTokens {
 
 // Icon sizes - standardized
 export const iconSize = {
-  xs: 14,
-  sm: 16,
-  md: 18,
-  lg: 20,
-  xl: 24,
-  '2xl': 32,
-  '3xl': 40,
+  xs: 12,
+  sm: 14,
+  md: 16,
+  lg: 18,
+  xl: 22,
+  '2xl': 28,
+  '3xl': 36,
 } as const;
 
 // Dot indicator sizes (colored dots in chips/tags)
@@ -107,12 +107,12 @@ export const dotSize = {
 
 // Icon container sizes (circles around icons)
 export const iconContainer = {
-  xs: 36,
-  sm: 32,
-  md: 40,
-  lg: 48,
-  xl: 56,
-  '2xl': 80,
+  xs: 30,
+  sm: 28,
+  md: 36,
+  lg: 42,
+  xl: 48,
+  '2xl': 68,
 } as const;
 
 export type IconContainerSize = keyof typeof iconContainer;

--- a/mobile/lib/theme/typography.ts
+++ b/mobile/lib/theme/typography.ts
@@ -62,29 +62,29 @@ export const fontFamilyWeight = {
 // Rule of thumb: micro/eyebrow sizes start at 12; default body sits at 14–15;
 // reading body at 16; section headings at 18–22; screen titles at 24–32.
 export const fontSize = {
-  xs: 12,
-  sm: 13,
-  base: 14,
-  md: 15,
-  lg: 16,
-  xl: 18,
-  'lg-xl': 19,
-  '2xl': 20,
-  'xl-2xl': 22,
-  '3xl': 24,
-  '3xl-4xl': 30,
-  '4xl': 28,
-  '5xl': 36,
-  '6xl': 44,
+  xs: 11,
+  sm: 12,
+  base: 13,
+  md: 14,
+  lg: 15,
+  xl: 16,
+  'lg-xl': 17,
+  '2xl': 18,
+  'xl-2xl': 19,
+  '3xl': 21,
+  '3xl-4xl': 24,
+  '4xl': 24,
+  '5xl': 30,
+  '6xl': 36,
 } as const;
 
-// Line-height ramp aligned to the new font sizes (~1.4–1.5× body, ~1.25 headings).
+// Line-height ramp aligned to the new font sizes (~1.4× body, ~1.2 headings).
 export const lineHeight = {
-  sm: 18,
-  md: 20,
-  lg: 24,
-  xl: 26,
-  '2xl': 30,
+  sm: 16,
+  md: 18,
+  lg: 22,
+  xl: 24,
+  '2xl': 28,
 } as const;
 
 // Font weights for typography hierarchy
@@ -113,88 +113,88 @@ export const createTypography = (fonts: FontFamilyTokens) =>
     displayLarge: {
       fontFamily: fonts.displayBold,
       fontSize: fontSize['6xl'],
-      lineHeight: 48,
+      lineHeight: 40,
       letterSpacing: letterSpacing.tighter,
     },
     displayMedium: {
       fontFamily: fonts.display,
       fontSize: fontSize['4xl'],
-      lineHeight: 34,
+      lineHeight: 30,
       letterSpacing: letterSpacing.tight,
     },
     displaySmall: {
       fontFamily: fonts.display,
       fontSize: fontSize['3xl'],
-      lineHeight: 30,
+      lineHeight: 26,
       letterSpacing: letterSpacing.snug,
     },
 
     headingLarge: {
       fontFamily: fonts.bodyBold,
       fontSize: fontSize['3xl'],
-      lineHeight: 30,
+      lineHeight: 26,
       letterSpacing: letterSpacing.snug,
     },
     headingMedium: {
       fontFamily: fonts.bodySemibold,
       fontSize: fontSize['2xl'],
-      lineHeight: 26,
+      lineHeight: 22,
       letterSpacing: letterSpacing.normal,
     },
     headingSmall: {
       fontFamily: fonts.bodySemibold,
       fontSize: fontSize.xl,
-      lineHeight: 24,
+      lineHeight: 20,
       letterSpacing: letterSpacing.normal,
     },
 
     bodyLarge: {
       fontFamily: fonts.body,
       fontSize: fontSize.lg,
-      lineHeight: 24,
+      lineHeight: 22,
     },
     bodyMedium: {
       fontFamily: fonts.body,
       fontSize: fontSize.md,
-      lineHeight: 22,
+      lineHeight: 20,
     },
     bodySmall: {
       fontFamily: fonts.body,
       fontSize: fontSize.base,
-      lineHeight: 20,
+      lineHeight: 18,
     },
 
     labelLarge: {
       fontFamily: fonts.bodySemibold,
       fontSize: fontSize.lg,
-      lineHeight: 20,
+      lineHeight: 18,
     },
     labelMedium: {
       fontFamily: fonts.bodySemibold,
       fontSize: fontSize.md,
-      lineHeight: 20,
+      lineHeight: 18,
     },
     labelSmall: {
       fontFamily: fonts.bodySemibold,
       fontSize: fontSize.sm,
-      lineHeight: 18,
+      lineHeight: 16,
     },
 
     caption: {
       fontFamily: fonts.bodyMedium,
       fontSize: fontSize.base,
-      lineHeight: 20,
+      lineHeight: 18,
     },
     captionSmall: {
       fontFamily: fonts.bodyMedium,
       fontSize: fontSize.sm,
-      lineHeight: 18,
+      lineHeight: 16,
     },
 
     overline: {
       fontFamily: fonts.bodySemibold,
       fontSize: fontSize.xs,
-      lineHeight: 16,
+      lineHeight: 14,
       letterSpacing: letterSpacing.wider,
       textTransform: 'uppercase' as const,
     },

--- a/mobile/lib/theme/typography.ts
+++ b/mobile/lib/theme/typography.ts
@@ -56,11 +56,11 @@ export const fontFamilyWeight = {
   accent: '500' as const,
 };
 
-// Typography scale — modernized in Phase 1 of the design-system refresh.
+// Typography scale — tightened for a more compact, modern UI.
 // Token keys are preserved (large blast radius) but values are bumped to a
-// contemporary ramp (body 14–16, headings 18–28, display 30–44).
-// Rule of thumb: micro/eyebrow sizes start at 12; default body sits at 14–15;
-// reading body at 16; section headings at 18–22; screen titles at 24–32.
+// smaller ramp (body 13–15, headings 16–24, display 24–36).
+// Rule of thumb: micro/eyebrow sizes start at 11; default body sits at 13–14;
+// reading body at 15; section headings at 16–18; screen titles at 21–24.
 export const fontSize = {
   xs: 11,
   sm: 12,


### PR DESCRIPTION
## Summary

Tightens the mobile design tokens so the UI feels lighter, more modern, and less "for old people":

- **Typography** (`mobile/lib/theme/typography.ts`): font scale shifted down ~1pt across the ramp (body 14→13, lg 16→15, headings 18/20/24/28→16/18/21/24, display 36/44→30/36). Line-heights compressed proportionally in all presets.
- **Spacing** (`mobile/lib/theme/layout.ts`):
  - half-step spacings tightened (xs-sm 8→6, sm-md 12→10, md-lg 16→14)
  - larger steps trimmed (xl 24→20, 2xl 32→28, 3xl 40→36, 4xl 48→44)
  - `sectionGap` 32→24, `cardGap` 8→6
  - `screenPaddingTop` 48→32, `screenPaddingHorizontal` 24→20
- **Icons**: `iconSize` shifted down one step (xl 24→22, lg 20→18, md 18→16…); `iconContainer` reduced (lg 48→42, xl 56→48, 2xl 80→68).

All token *keys* unchanged — only values. Because every screen reads from these tokens via `useTheme()`, the entire app instantly becomes more compact without per-component edits.

## Tests

`pnpm test --run` → 819/819 passing. Test mocks in `mobile/test/setup.ts` use their own values and were unaffected.
