### PR TITLE
fix: improve grocery clear-picked and re-add behavior

### DIFF
--- a/mobile/components/GroceryListView.tsx
+++ b/mobile/components/GroceryListView.tsx
@@ -25,7 +25,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useTranslation } from '@/lib/i18n';
 
-import { fontSize, iconSize, layout, spacing, useTheme } from '@/lib/theme';
+import {
+  borderRadius,
+  fontSize,
+  iconSize,
+  layout,
+  spacing,
+  useTheme,
+} from '@/lib/theme';
 import type { GroceryItem } from '@/lib/types';
 import { Button } from './Button';
 import { ContentCard } from './ContentCard';
@@ -323,12 +330,15 @@ export const GroceryListView = ({
           >
             <Button
               variant="text"
-              tone="subtle"
+              tone="glassSolid"
               size="sm"
               icon="checkmark-done-outline"
               label={t('grocery.clearPickedButton')}
               onPress={onClearPicked}
               testID="clear-picked"
+              hoverScale={1.08}
+              pressScale={0.95}
+              style={{ borderRadius: borderRadius.full }}
             />
           </View>
         )}

--- a/mobile/components/GroceryListView.tsx
+++ b/mobile/components/GroceryListView.tsx
@@ -25,14 +25,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useTranslation } from '@/lib/i18n';
 
-import {
-  borderRadius,
-  fontSize,
-  iconSize,
-  layout,
-  spacing,
-  useTheme,
-} from '@/lib/theme';
+import { fontSize, iconSize, layout, spacing, useTheme } from '@/lib/theme';
 import type { GroceryItem } from '@/lib/types';
 import { Button } from './Button';
 import { ContentCard } from './ContentCard';
@@ -113,7 +106,7 @@ export const GroceryListView = ({
   onReorder,
   onClearPicked,
 }: GroceryListViewProps) => {
-  const { colors, fonts } = useTheme();
+  const { borderRadius, colors, fonts } = useTheme();
   const { t } = useTranslation();
   const [orderedItems, setOrderedItems] = useState<GroceryItem[]>([]);
   const orderedItemsRef = useRef<GroceryItem[]>([]);

--- a/mobile/lib/__tests__/grocery-context.test.tsx
+++ b/mobile/lib/__tests__/grocery-context.test.tsx
@@ -284,11 +284,10 @@ describe('GroceryProvider', () => {
       expect(mockPatchGroceryState).toHaveBeenCalledWith({
         selected_meals: ['monday-lunch', 'tuesday-dinner'],
         meal_servings: { 'monday-lunch': 4, 'tuesday-dinner': 2 },
-        removed_items: [],
       });
     });
 
-    it('clears removed items but preserves checked items when saving new selections', async () => {
+    it('preserves removed items and checked items when saving new selections', async () => {
       mockGetGroceryState.mockResolvedValue({
         ...emptyState,
         selected_meals: ['monday-lunch'],
@@ -299,10 +298,10 @@ describe('GroceryProvider', () => {
 
       mockPatchGroceryState.mockResolvedValue({
         ...emptyState,
-        selected_meals: ['tuesday-dinner'],
-        meal_servings: { 'tuesday-dinner': 4 },
+        selected_meals: ['monday-lunch', 'tuesday-dinner'],
+        meal_servings: { 'monday-lunch': 2, 'tuesday-dinner': 4 },
         checked_items: ['flour', 'sugar'],
-        removed_items: [],
+        removed_items: ['butter'],
       });
 
       const { result } = renderHook(() => useGroceryState(), {
@@ -315,17 +314,50 @@ describe('GroceryProvider', () => {
 
       await act(async () => {
         await result.current.saveSelections(
-          ['tuesday-dinner'],
-          { 'tuesday-dinner': 4 },
+          ['monday-lunch', 'tuesday-dinner'],
+          { 'monday-lunch': 2, 'tuesday-dinner': 4 },
         );
       });
 
       expect(result.current.checkedItems.size).toBe(2);
-      expect(result.current.removedItems).toEqual([]);
+      expect(result.current.removedItems).toEqual(['butter']);
+      expect(mockPatchGroceryState).toHaveBeenCalledWith({
+        selected_meals: ['monday-lunch', 'tuesday-dinner'],
+        meal_servings: { 'monday-lunch': 2, 'tuesday-dinner': 4 },
+      });
+    });
+
+    it('applies an explicit removed items override when provided', async () => {
+      mockGetGroceryState.mockResolvedValue({
+        ...emptyState,
+        removed_items: ['butter', 'milk'],
+      });
+
+      mockPatchGroceryState.mockResolvedValue({
+        ...emptyState,
+        selected_meals: ['tuesday-dinner'],
+        meal_servings: { 'tuesday-dinner': 4 },
+        removed_items: ['milk'],
+      });
+
+      const { result } = renderHook(() => useGroceryState(), {
+        wrapper: createGroceryWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.saveSelections(
+          ['tuesday-dinner'],
+          { 'tuesday-dinner': 4 },
+          ['milk'],
+        );
+      });
+
+      expect(result.current.removedItems).toEqual(['milk']);
       expect(mockPatchGroceryState).toHaveBeenCalledWith({
         selected_meals: ['tuesday-dinner'],
         meal_servings: { 'tuesday-dinner': 4 },
-        removed_items: [],
+        removed_items: ['milk'],
       });
     });
   });

--- a/mobile/lib/grocery-context.tsx
+++ b/mobile/lib/grocery-context.tsx
@@ -40,6 +40,7 @@ interface GroceryContextValue {
   saveSelections: (
     meals: string[],
     servings: Record<string, number>,
+    removedItems?: string[],
   ) => Promise<void>;
   clearAll: () => Promise<void>;
   refreshFromApi: () => Promise<void>;
@@ -352,7 +353,11 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
   );
 
   const saveSelections = useCallback(
-    async (meals: string[], servings: Record<string, number>) => {
+    async (
+      meals: string[],
+      servings: Record<string, number>,
+      removedItemsOverride?: string[],
+    ) => {
       if (patchTimerRef.current) {
         clearTimeout(patchTimerRef.current);
         patchTimerRef.current = null;
@@ -361,8 +366,6 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
 
       setSelectedMealKeys(meals);
       setMealServings(servings);
-      setRemovedItemsState([]);
-      removedItemsRef.current = [];
 
       AsyncStorage.setItem(
         'grocery_selected_meals',
@@ -375,7 +378,9 @@ export const GroceryProvider = ({ children }: { children: ReactNode }) => {
       const response = await api.patchGroceryState({
         selected_meals: meals,
         meal_servings: servings,
-        removed_items: [],
+        ...(removedItemsOverride !== undefined
+          ? { removed_items: removedItemsOverride }
+          : {}),
       });
       applyState(response);
       cacheToAsyncStorage({

--- a/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
+++ b/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
@@ -24,6 +24,7 @@ const mockMealPlan = {
     '2026-01-05_lunch': 'recipe-1',
     '2026-01-05_dinner': 'custom:Pasta night',
     '2026-01-06_lunch': 'unknown-id',
+    '2026-01-06_dinner': 'recipe-2',
   },
   notes: {
     '2026-01-05': 'Office Gym',
@@ -36,6 +37,14 @@ const mockRecipes: Recipe[] = [
     title: 'Chicken Curry',
     ingredients: ['chicken', 'curry paste'],
     instructions: ['Cook chicken', 'Add curry'],
+    visibility: 'household',
+    household_id: 'h1',
+  }),
+  mockRecipe({
+    id: 'recipe-2',
+    title: 'Chicken Rice Bowl',
+    ingredients: ['chicken', 'rice'],
+    instructions: ['Cook chicken', 'Serve with rice'],
     visibility: 'household',
     household_id: 'h1',
   }),
@@ -270,6 +279,36 @@ describe('useMealPlanActions', () => {
         removedItems: [] as string[],
       } as unknown as ReturnType<typeof useGroceryState>);
     });
+
+    it('does not restore shared ingredients when adding a different meal later', async () => {
+      const { useGroceryState } = await import('@/lib/hooks');
+      vi.mocked(useGroceryState).mockReturnValue({
+        saveSelections: mockSaveSelections,
+        selectedMealKeys: ['2026-01-05_lunch'],
+        mealServings: { '2026-01-05_lunch': 4 },
+        removedItems: ['chicken'],
+      } as unknown as ReturnType<typeof useGroceryState>);
+
+      const { result } = renderActions();
+
+      act(() =>
+        result.current.handleToggleMeal(new Date('2026-01-06'), 'dinner', 2),
+      );
+      await act(() => result.current.handleCreateGroceryList());
+
+      expect(mockSaveSelections).toHaveBeenCalledWith(
+        expect.arrayContaining(['2026-01-05_lunch', '2026-01-06_dinner']),
+        { '2026-01-05_lunch': 4, '2026-01-06_dinner': 2 },
+        ['chicken'],
+      );
+
+      vi.mocked(useGroceryState).mockReturnValue({
+        saveSelections: mockSaveSelections,
+        selectedMealKeys: [] as string[],
+        mealServings: {} as Record<string, number>,
+        removedItems: [] as string[],
+      } as unknown as ReturnType<typeof useGroceryState>);
+    });
   });
 
   describe('handleMealPress', () => {
@@ -383,8 +422,8 @@ describe('useMealPlanActions', () => {
 
     it('counts only matching meal types (unknown-id counts as present)', () => {
       const { result } = renderActions();
-      // 2026-01-06 has only lunch (unknown-id) = 1
-      expect(result.current.countMealsForDate(new Date('2026-01-06'))).toBe(1);
+      // 2026-01-06 has lunch (unknown-id) and dinner (recipe-2) = 2
+      expect(result.current.countMealsForDate(new Date('2026-01-06'))).toBe(2);
     });
   });
 

--- a/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
+++ b/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/lib/hooks', () => ({
     saveSelections: mockSaveSelections,
     selectedMealKeys: [] as string[],
     mealServings: {} as Record<string, number>,
+    removedItems: [] as string[],
   })),
 }));
 
@@ -209,6 +210,7 @@ describe('useMealPlanActions', () => {
       expect(mockSaveSelections).toHaveBeenCalledWith(
         ['2026-01-05_lunch'],
         { '2026-01-05_lunch': 4 },
+        [],
       );
       expect(result.current.showGroceryModal).toBe(false);
     });
@@ -219,6 +221,7 @@ describe('useMealPlanActions', () => {
         saveSelections: mockSaveSelections,
         selectedMealKeys: ['2026-01-06_dinner'],
         mealServings: { '2026-01-06_dinner': 2 },
+        removedItems: [] as string[],
       } as unknown as ReturnType<typeof useGroceryState>);
 
       const { result } = renderActions();
@@ -229,12 +232,42 @@ describe('useMealPlanActions', () => {
       expect(mockSaveSelections).toHaveBeenCalledWith(
         expect.arrayContaining(['2026-01-06_dinner', '2026-01-05_lunch']),
         { '2026-01-06_dinner': 2, '2026-01-05_lunch': 4 },
+        [],
       );
 
       vi.mocked(useGroceryState).mockReturnValue({
         saveSelections: mockSaveSelections,
         selectedMealKeys: [] as string[],
         mealServings: {} as Record<string, number>,
+        removedItems: [] as string[],
+      } as unknown as ReturnType<typeof useGroceryState>);
+    });
+
+    it('restores removed items for meals explicitly selected again', async () => {
+      const { useGroceryState } = await import('@/lib/hooks');
+      vi.mocked(useGroceryState).mockReturnValue({
+        saveSelections: mockSaveSelections,
+        selectedMealKeys: ['2026-01-05_lunch'],
+        mealServings: { '2026-01-05_lunch': 4 },
+        removedItems: ['chicken', 'curry paste', 'butter'],
+      } as unknown as ReturnType<typeof useGroceryState>);
+
+      const { result } = renderActions();
+
+      act(() => result.current.handleToggleMeal(new Date('2026-01-05'), 'lunch', 4));
+      await act(() => result.current.handleCreateGroceryList());
+
+      expect(mockSaveSelections).toHaveBeenCalledWith(
+        ['2026-01-05_lunch'],
+        { '2026-01-05_lunch': 4 },
+        ['butter'],
+      );
+
+      vi.mocked(useGroceryState).mockReturnValue({
+        saveSelections: mockSaveSelections,
+        selectedMealKeys: [] as string[],
+        mealServings: {} as Record<string, number>,
+        removedItems: [] as string[],
       } as unknown as ReturnType<typeof useGroceryState>);
     });
   });

--- a/mobile/lib/hooks/useMealPlanActions.ts
+++ b/mobile/lib/hooks/useMealPlanActions.ts
@@ -442,9 +442,12 @@ export const useMealPlanActions = () => {
       const newMeals = Array.from(selectedMeals);
       const mergedMeals = [...new Set([...existingMealKeys, ...newMeals])];
       const mergedServings = { ...existingServings, ...mealServings };
+      const readdedMealKeys = newMeals.filter((key) =>
+        existingMealKeys.includes(key),
+      );
       const restoredItemNames = new Set(
         aggregateIngredients(
-          newMeals,
+          readdedMealKeys,
           mealPlan?.meals ?? {},
           recipes,
           mergedServings,

--- a/mobile/lib/hooks/useMealPlanActions.ts
+++ b/mobile/lib/hooks/useMealPlanActions.ts
@@ -18,7 +18,10 @@ import { useTranslation } from '@/lib/i18n';
 import { useSettings } from '@/lib/settings-context';
 import type { MealType, Recipe } from '@/lib/types';
 import { formatDateLocal, getWeekDatesArray } from '@/lib/utils/dateFormatter';
-import { EXTRAS_KEY_PREFIX } from '@/lib/utils/groceryAggregator';
+import {
+  aggregateIngredients,
+  EXTRAS_KEY_PREFIX,
+} from '@/lib/utils/groceryAggregator';
 
 export const useMealPlanActions = () => {
   const router = useRouter();
@@ -28,6 +31,7 @@ export const useMealPlanActions = () => {
     saveSelections,
     selectedMealKeys: existingMealKeys,
     mealServings: existingServings,
+    removedItems,
   } = useGroceryState();
 
   const MEAL_TYPES: MealTypeOption[] = useMemo(() => {
@@ -438,7 +442,19 @@ export const useMealPlanActions = () => {
       const newMeals = Array.from(selectedMeals);
       const mergedMeals = [...new Set([...existingMealKeys, ...newMeals])];
       const mergedServings = { ...existingServings, ...mealServings };
-      await saveSelections(mergedMeals, mergedServings);
+      const restoredItemNames = new Set(
+        aggregateIngredients(
+          newMeals,
+          mealPlan?.meals ?? {},
+          recipes,
+          mergedServings,
+        ).map((item) => item.name),
+      );
+      const nextRemovedItems =
+        restoredItemNames.size === 0
+          ? removedItems
+          : removedItems.filter((name) => !restoredItemNames.has(name));
+      await saveSelections(mergedMeals, mergedServings, nextRemovedItems);
       setShowGroceryModal(false);
       setTimeout(() => router.push('/(tabs)/grocery'), 100);
     } catch {
@@ -449,6 +465,9 @@ export const useMealPlanActions = () => {
     mealServings,
     existingMealKeys,
     existingServings,
+    mealPlan?.meals,
+    recipes,
+    removedItems,
     router,
     t,
     saveSelections,

--- a/mobile/lib/utils/groceryAggregator.ts
+++ b/mobile/lib/utils/groceryAggregator.ts
@@ -17,7 +17,7 @@ export interface RecipeForAggregation {
   id: string;
   title: string;
   ingredients: string[];
-  servings?: number;
+  servings?: number | null;
 }
 
 export const EXTRAS_KEY_PREFIX = 'extras_';


### PR DESCRIPTION
## Summary
- restyle the Clear Picked action so it is more visible and matches the grocery action buttons
- preserve cleared generated grocery items when adding other meals later
- restore removed ingredient names when a user explicitly re-adds the same meal from the weekly menu
- align grocery aggregation typing with nullable recipe servings
- add focused tests for grocery state persistence and meal re-add behavior

## Testing
- `cd mobile && pnpm vitest run --reporter=verbose grocery-context useMealPlanActions`
- pre-commit hooks passed, including mobile TypeScript and Biome