### PR TITLE
feat: improve shared recipe copy and meal slot attribution

### DIFF
--- a/api/models/meal_plan.py
+++ b/api/models/meal_plan.py
@@ -40,7 +40,8 @@ class MealPlan(BaseModel):
     meals: dict[str, str] = Field(default_factory=dict, description="Map of date_mealtype to recipe_id or custom:text")
     notes: dict[str, str] = Field(default_factory=dict, description="Map of date to note text")
     last_modified_by: dict[str, str] = Field(
-        default_factory=dict, description="Map of date_mealtype to the email of the user who last changed that slot"
+        default_factory=dict,
+        description="Map of date_mealtype to a display-safe initials label for the user who last changed that slot",
     )
     extras: dict[str, list[str]] = Field(
         default_factory=dict, description="Week-keyed recipe IDs for 'Other' section (key = week start date)"

--- a/api/models/meal_plan.py
+++ b/api/models/meal_plan.py
@@ -28,6 +28,7 @@ class PlannedMeal(BaseModel):
     recipe_id: str | None = None
     recipe_title: str | None = None
     notes: str | None = None
+    last_modified_by: str | None = None
 
 
 class MealPlan(BaseModel):
@@ -38,6 +39,9 @@ class MealPlan(BaseModel):
     household_id: str = Field(..., description="Household identifier")
     meals: dict[str, str] = Field(default_factory=dict, description="Map of date_mealtype to recipe_id or custom:text")
     notes: dict[str, str] = Field(default_factory=dict, description="Map of date to note text")
+    last_modified_by: dict[str, str] = Field(
+        default_factory=dict, description="Map of date_mealtype to the email of the user who last changed that slot"
+    )
     extras: dict[str, list[str]] = Field(
         default_factory=dict, description="Week-keyed recipe IDs for 'Other' section (key = week start date)"
     )
@@ -58,6 +62,7 @@ class MealPlan(BaseModel):
                             meal_type=meal_type,
                             recipe_id=None if is_custom else value,
                             recipe_title=value[7:] if is_custom else None,
+                            last_modified_by=self.last_modified_by.get(key),
                         )
                     )
         return result
@@ -76,6 +81,7 @@ class MealPlan(BaseModel):
                         meal_type=meal_type,
                         recipe_id=None if is_custom else value,
                         recipe_title=value[7:] if is_custom else None,
+                        last_modified_by=self.last_modified_by.get(key),
                     )
                 )
         return result

--- a/api/routers/grocery.py
+++ b/api/routers/grocery.py
@@ -83,9 +83,13 @@ async def generate_grocery_list(
 
     recipe_ids, custom_meal_texts = _collect_meal_entries(meals, effective_start, effective_end)
 
-    # Also include extras (Other section) - these are not date-bound
-    for extra_id in extras:
-        recipe_ids.add(extra_id)
+    # Also include extras (Other section) - these are not date-bound.
+    # Stored shape is week-keyed lists, but accept a flat list defensively.
+    if isinstance(extras, dict):
+        for week_extras in extras.values():
+            recipe_ids.update(week_extras)
+    else:
+        recipe_ids.update(extras)
 
     # Load recipes and collect ingredients
     grocery_list = GroceryList()

--- a/api/routers/grocery.py
+++ b/api/routers/grocery.py
@@ -79,7 +79,7 @@ async def generate_grocery_list(
     effective_end = end_date if end_date is not None else effective_start + timedelta(days=days - 1)
 
     # Load meal plan
-    meals, _, extras = meal_plan_storage.load_meal_plan(household_id)
+    meals, _, _, extras = meal_plan_storage.load_meal_plan(household_id)
 
     recipe_ids, custom_meal_texts = _collect_meal_entries(meals, effective_start, effective_end)
 

--- a/api/routers/meal_plans.py
+++ b/api/routers/meal_plans.py
@@ -15,6 +15,21 @@ router = APIRouter(prefix="/meal-plans", tags=["meal-plans"])
 
 # Expected number of parts when splitting meal key
 _MEAL_KEY_PARTS = 2
+_INITIALS_SEGMENTS = 2
+
+
+def _build_modifier_label(user: AuthenticatedUser) -> str:
+    """Build a display-safe initials label for slot attribution."""
+    source = (user.name or user.email).strip()
+    local_part = source.split("@", 1)[0].strip()
+    if not local_part:
+        return ""
+
+    segments = [segment.strip() for segment in local_part.replace("-", " ").replace("_", " ").replace(".", " ").split()]
+    segments = [segment for segment in segments if segment]
+    if len(segments) >= _INITIALS_SEGMENTS:
+        return f"{segments[0][0]}{segments[1][0]}".upper()
+    return local_part[:_INITIALS_SEGMENTS].upper()
 
 
 class MealUpdateRequest(BaseModel):
@@ -122,7 +137,7 @@ async def update_meal_plan(
         if value is None:
             meal_plan_storage.delete_meal(resolved_id, date_str, meal_type_str)
         else:
-            meal_plan_storage.update_meal(resolved_id, date_str, meal_type_str, value, user.email)
+            meal_plan_storage.update_meal(resolved_id, date_str, meal_type_str, value, _build_modifier_label(user))
 
     # Process note updates
     for date_str, note in updates.notes.items():
@@ -156,7 +171,9 @@ async def update_single_meal(
     if request.value is None:
         meal_plan_storage.delete_meal(resolved_id, date_str, request.meal_type)
     else:
-        meal_plan_storage.update_meal(resolved_id, date_str, request.meal_type, request.value, user.email)
+        meal_plan_storage.update_meal(
+            resolved_id, date_str, request.meal_type, request.value, _build_modifier_label(user)
+        )
 
     meals, notes, last_modified_by, extras = meal_plan_storage.load_meal_plan(resolved_id)
     return MealPlan(

--- a/api/routers/meal_plans.py
+++ b/api/routers/meal_plans.py
@@ -89,8 +89,10 @@ async def get_meal_plan(
     Superusers can specify any household_id to view.
     """
     resolved_id = _resolve_household(user, household_id)
-    meals, notes, extras = meal_plan_storage.load_meal_plan(resolved_id)
-    return MealPlan(household_id=resolved_id, meals=meals, notes=notes, extras=extras)
+    meals, notes, last_modified_by, extras = meal_plan_storage.load_meal_plan(resolved_id)
+    return MealPlan(
+        household_id=resolved_id, meals=meals, notes=notes, last_modified_by=last_modified_by, extras=extras
+    )
 
 
 @router.put("")
@@ -120,7 +122,7 @@ async def update_meal_plan(
         if value is None:
             meal_plan_storage.delete_meal(resolved_id, date_str, meal_type_str)
         else:
-            meal_plan_storage.update_meal(resolved_id, date_str, meal_type_str, value)
+            meal_plan_storage.update_meal(resolved_id, date_str, meal_type_str, value, user.email)
 
     # Process note updates
     for date_str, note in updates.notes.items():
@@ -132,8 +134,10 @@ async def update_meal_plan(
             meal_plan_storage.update_extras(resolved_id, week, week_extras)
 
     # Return updated meal plan
-    meals, notes, extras = meal_plan_storage.load_meal_plan(resolved_id)
-    return MealPlan(household_id=resolved_id, meals=meals, notes=notes, extras=extras)
+    meals, notes, last_modified_by, extras = meal_plan_storage.load_meal_plan(resolved_id)
+    return MealPlan(
+        household_id=resolved_id, meals=meals, notes=notes, last_modified_by=last_modified_by, extras=extras
+    )
 
 
 @router.post("/meals")
@@ -152,10 +156,12 @@ async def update_single_meal(
     if request.value is None:
         meal_plan_storage.delete_meal(resolved_id, date_str, request.meal_type)
     else:
-        meal_plan_storage.update_meal(resolved_id, date_str, request.meal_type, request.value)
+        meal_plan_storage.update_meal(resolved_id, date_str, request.meal_type, request.value, user.email)
 
-    meals, notes, extras = meal_plan_storage.load_meal_plan(resolved_id)
-    return MealPlan(household_id=resolved_id, meals=meals, notes=notes, extras=extras)
+    meals, notes, last_modified_by, extras = meal_plan_storage.load_meal_plan(resolved_id)
+    return MealPlan(
+        household_id=resolved_id, meals=meals, notes=notes, last_modified_by=last_modified_by, extras=extras
+    )
 
 
 @router.post("/notes")
@@ -171,8 +177,10 @@ async def update_single_note(
     resolved_id = _resolve_household(user, household_id)
     meal_plan_storage.update_day_note(resolved_id, request.date.isoformat(), request.note)
 
-    meals, notes, extras = meal_plan_storage.load_meal_plan(resolved_id)
-    return MealPlan(household_id=resolved_id, meals=meals, notes=notes, extras=extras)
+    meals, notes, last_modified_by, extras = meal_plan_storage.load_meal_plan(resolved_id)
+    return MealPlan(
+        household_id=resolved_id, meals=meals, notes=notes, last_modified_by=last_modified_by, extras=extras
+    )
 
 
 @router.delete("", status_code=status.HTTP_204_NO_CONTENT)
@@ -185,7 +193,7 @@ async def clear_meal_plan(
     Superusers can specify household_id to clear any household.
     """
     resolved_id = _resolve_household(user, household_id)
-    meal_plan_storage.save_meal_plan(resolved_id, {}, {}, {})
+    meal_plan_storage.save_meal_plan(resolved_id, {}, {}, {}, {})
 
 
 @router.post("/extras")
@@ -202,5 +210,7 @@ async def update_extras(
     resolved_id = _resolve_household(user, household_id)
     meal_plan_storage.update_extras(resolved_id, request.week, request.extras)
 
-    meals, notes, extras = meal_plan_storage.load_meal_plan(resolved_id)
-    return MealPlan(household_id=resolved_id, meals=meals, notes=notes, extras=extras)
+    meals, notes, last_modified_by, extras = meal_plan_storage.load_meal_plan(resolved_id)
+    return MealPlan(
+        household_id=resolved_id, meals=meals, notes=notes, last_modified_by=last_modified_by, extras=extras
+    )

--- a/api/storage/meal_plan_storage.py
+++ b/api/storage/meal_plan_storage.py
@@ -21,6 +21,7 @@ def save_meal_plan(
     household_id: str,
     meals: dict[str, str],
     notes: dict[str, str] | None = None,
+    last_modified_by: dict[str, str] | None = None,
     extras: dict[str, list[str]] | None = None,
 ) -> None:  # pragma: no cover
     """
@@ -30,6 +31,8 @@ def save_meal_plan(
         household_id: The household identifier.
         meals: Dictionary with date_mealtype keys and recipe_id/custom values.
         notes: Optional dictionary with date keys and note text values.
+        last_modified_by: Optional dictionary with date_mealtype keys and
+            email values for the user who last changed each slot.
         extras: Optional week-keyed dict of recipe ID lists for the "Other" section.
     """
     db = get_firestore_client()
@@ -38,6 +41,8 @@ def save_meal_plan(
     data: dict[str, Any] = {"meals": meals, "updated_at": datetime.now(tz=UTC)}
     if notes is not None:
         data["notes"] = notes
+    if last_modified_by is not None:
+        data["last_modified_by"] = last_modified_by
     if extras is not None:
         data["extras"] = extras
 
@@ -46,7 +51,7 @@ def save_meal_plan(
 
 def load_meal_plan(
     household_id: str,
-) -> tuple[dict[str, str], dict[str, str], dict[str, list[str]]]:  # pragma: no cover
+) -> tuple[dict[str, str], dict[str, str], dict[str, str], dict[str, list[str]]]:  # pragma: no cover
     """
     Load the meal plan from Firestore.
 
@@ -54,7 +59,7 @@ def load_meal_plan(
         household_id: The household identifier.
 
     Returns:
-        Tuple of (meals dict, notes dict, extras week-keyed dict).
+        Tuple of (meals dict, notes dict, last_modified_by dict, extras week-keyed dict).
     """
     db = get_firestore_client()
     doc = cast(
@@ -62,16 +67,18 @@ def load_meal_plan(
     )
 
     if not doc.exists:
-        return {}, {}, {}
+        return {}, {}, {}, {}
 
     data = doc.to_dict()
     if data is None:
-        return {}, {}, {}
+        return {}, {}, {}, {}
 
-    return data.get("meals", {}), data.get("notes", {}), data.get("extras", {})
+    return data.get("meals", {}), data.get("notes", {}), data.get("last_modified_by", {}), data.get("extras", {})
 
 
-def update_meal(household_id: str, date_str: str, meal_type_str: str, value: str) -> None:  # pragma: no cover
+def update_meal(
+    household_id: str, date_str: str, meal_type_str: str, value: str, modified_by: str
+) -> None:  # pragma: no cover
     """
     Update a single meal in the meal plan.
 
@@ -80,12 +87,15 @@ def update_meal(household_id: str, date_str: str, meal_type_str: str, value: str
         date_str: The ISO date string of the meal.
         meal_type_str: The meal type value (breakfast, lunch, dinner, snack).
         value: The recipe ID or custom text (prefixed with "custom:").
+        modified_by: Email of the user who changed the slot.
     """
     db = get_firestore_client()
     doc_ref = db.collection(MEAL_PLANS_COLLECTION).document(_get_meal_plan_doc_id(household_id))
 
     key = f"{date_str}_{meal_type_str}"
-    doc_ref.set({"meals": {key: value}, "updated_at": datetime.now(tz=UTC)}, merge=True)
+    doc_ref.set(
+        {"meals": {key: value}, "last_modified_by": {key: modified_by}, "updated_at": datetime.now(tz=UTC)}, merge=True
+    )
 
 
 def delete_meal(household_id: str, date_str: str, meal_type_str: str) -> None:  # pragma: no cover
@@ -107,7 +117,8 @@ def delete_meal(household_id: str, date_str: str, meal_type_str: str) -> None:  
         return
 
     key = f"meals.{date_str}_{meal_type_str}"
-    doc_ref.update({key: DELETE_FIELD, "updated_at": datetime.now(tz=UTC)})
+    meta_key = f"last_modified_by.{date_str}_{meal_type_str}"
+    doc_ref.update({key: DELETE_FIELD, meta_key: DELETE_FIELD, "updated_at": datetime.now(tz=UTC)})
 
 
 def update_day_note(household_id: str, date_str: str, note: str) -> None:  # pragma: no cover

--- a/api/storage/meal_plan_storage.py
+++ b/api/storage/meal_plan_storage.py
@@ -32,7 +32,7 @@ def save_meal_plan(
         meals: Dictionary with date_mealtype keys and recipe_id/custom values.
         notes: Optional dictionary with date keys and note text values.
         last_modified_by: Optional dictionary with date_mealtype keys and
-            email values for the user who last changed each slot.
+            display-safe initials values for the user who last changed each slot.
         extras: Optional week-keyed dict of recipe ID lists for the "Other" section.
     """
     db = get_firestore_client()
@@ -87,7 +87,7 @@ def update_meal(
         date_str: The ISO date string of the meal.
         meal_type_str: The meal type value (breakfast, lunch, dinner, snack).
         value: The recipe ID or custom text (prefixed with "custom:").
-        modified_by: Email of the user who changed the slot.
+        modified_by: Display-safe initials label of the user who changed the slot.
     """
     db = get_firestore_client()
     doc_ref = db.collection(MEAL_PLANS_COLLECTION).document(_get_meal_plan_doc_id(household_id))

--- a/mobile/app/(tabs)/meal-plan.tsx
+++ b/mobile/app/(tabs)/meal-plan.tsx
@@ -259,6 +259,7 @@ export default function MealPlanScreen() {
                         label={label}
                         recipe={meal.recipe}
                         customText={meal.customText}
+                        lastModifiedBy={meal.lastModifiedBy}
                         onRemove={handleRemoveMeal}
                         onMealPress={handleMealPress}
                         onEditCustomText={handleEditCustomText}

--- a/mobile/components/ThemedAlert.tsx
+++ b/mobile/components/ThemedAlert.tsx
@@ -16,6 +16,7 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
@@ -31,6 +32,10 @@ interface ThemedAlertProps {
 }
 
 const ANIMATION_DURATION = 200;
+const STACKED_ALERT_BREAKPOINT = 420;
+
+export const shouldStackAlertButtons = (buttonCount: number, width: number) =>
+  buttonCount > 2 && width < STACKED_ALERT_BREAKPOINT;
 
 const buttonTone = (style?: AlertButton['style']) => {
   if (style === 'destructive') return 'warning' as const;
@@ -68,6 +73,7 @@ const WebOverlay = ({ visible, children }: WrapperProps) => {
 
 export const ThemedAlert = ({ alert, onDismiss }: ThemedAlertProps) => {
   const { colors, fonts, borderRadius, shadows, chrome } = useTheme();
+  const { width } = useWindowDimensions();
   const opacity = useRef(new Animated.Value(0)).current;
   const scale = useRef(new Animated.Value(0.9)).current;
 
@@ -104,6 +110,10 @@ export const ThemedAlert = ({ alert, onDismiss }: ThemedAlertProps) => {
 
   const buttons = alert?.buttons;
   const hasButtons = buttons && buttons.length > 0;
+  const shouldStackButtons = shouldStackAlertButtons(
+    buttons?.length ?? 0,
+    width,
+  );
 
   // On web, RN Modal portals all share the same z-index so a second Modal
   // (this alert) can render *under* an already-open BottomSheetModal.
@@ -168,8 +178,10 @@ export const ThemedAlert = ({ alert, onDismiss }: ThemedAlertProps) => {
             <View
               style={[
                 styles.buttonRow,
+                { flexDirection: shouldStackButtons ? 'column' : 'row' },
                 { borderTopColor: colors.surface.divider },
               ]}
+              testID="alert-buttons"
             >
               {hasButtons ? (
                 buttons.map((button) => (

--- a/mobile/components/__tests__/themedalert-layout.test.ts
+++ b/mobile/components/__tests__/themedalert-layout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { shouldStackAlertButtons } from '../ThemedAlert';
+
+describe('shouldStackAlertButtons', () => {
+  it('stacks when there are more than two buttons on a narrow screen', () => {
+    expect(shouldStackAlertButtons(3, 360)).toBe(true);
+  });
+
+  it('keeps row layout on wide screens', () => {
+    expect(shouldStackAlertButtons(3, 768)).toBe(false);
+  });
+
+  it('keeps row layout for one or two buttons', () => {
+    expect(shouldStackAlertButtons(2, 360)).toBe(false);
+  });
+});

--- a/mobile/components/meal-plan/FilledMealSlot.tsx
+++ b/mobile/components/meal-plan/FilledMealSlot.tsx
@@ -7,6 +7,7 @@ interface FilledMealSlotProps {
   label: string;
   recipe?: Recipe;
   customText?: string;
+  lastModifiedBy?: string;
   onRemove: (
     date: Date,
     mealType: MealType,
@@ -32,6 +33,7 @@ export const FilledMealSlot = ({
   label,
   recipe,
   customText,
+  lastModifiedBy,
   onRemove,
   onMealPress,
   onEditCustomText,
@@ -39,6 +41,7 @@ export const FilledMealSlot = ({
 }: FilledMealSlotProps) => {
   const title = recipe?.title || customText || '';
   const imageUrl = recipe?.thumbnail_url || recipe?.image_url;
+  const cornerLabel = getInitials(lastModifiedBy);
 
   const handlePress = () => {
     if (recipe) {
@@ -55,8 +58,27 @@ export const FilledMealSlot = ({
       title={title}
       imageUrl={imageUrl}
       subtitle={label}
+      cornerLabel={cornerLabel}
       onPress={handlePress}
       onRemove={() => onRemove(date, mealType, title, label)}
     />
   );
+};
+
+const getInitials = (value?: string) => {
+  if (!value) return undefined;
+
+  const source = value.split('@')[0]?.trim() ?? '';
+  if (!source) return undefined;
+
+  const segments = source
+    .split(/[._\-\s]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (segments.length >= 2) {
+    return `${segments[0][0]}${segments[1][0]}`.toUpperCase();
+  }
+
+  return source.slice(0, 2).toUpperCase();
 };

--- a/mobile/components/meal-plan/RecipeRow.tsx
+++ b/mobile/components/meal-plan/RecipeRow.tsx
@@ -7,6 +7,7 @@ interface RecipeRowProps {
   title: string;
   imageUrl?: string | null;
   subtitle?: string;
+  cornerLabel?: string;
   onPress: () => void;
   onRemove: () => void;
 }
@@ -19,6 +20,7 @@ export const RecipeRow = ({
   title,
   imageUrl,
   subtitle,
+  cornerLabel,
   onPress,
   onRemove,
 }: RecipeRowProps) => {
@@ -29,7 +31,7 @@ export const RecipeRow = ({
     <View
       style={{
         flexDirection: 'row',
-        alignItems: 'center',
+        alignItems: 'stretch',
         backgroundColor: colors.mealPlan.slotBg,
         borderRadius: borderRadius.sm,
         padding: spacing.md,
@@ -78,14 +80,32 @@ export const RecipeRow = ({
         </View>
       </Pressable>
 
-      <IconButton
-        tone="cancel"
-        onPress={onRemove}
-        icon="close"
-        size={28}
-        iconSize={18}
-        style={{ marginLeft: spacing.sm }}
-      />
+      <View
+        style={{
+          marginLeft: spacing.sm,
+          justifyContent: 'space-between',
+          alignItems: 'flex-end',
+        }}
+      >
+        <IconButton
+          tone="cancel"
+          onPress={onRemove}
+          icon="close"
+          size={28}
+          iconSize={18}
+        />
+        {cornerLabel ? (
+          <Text
+            style={{
+              fontSize: fontSize.xs,
+              fontFamily: fonts.bodyMedium,
+              color: colors.content.tertiary,
+            }}
+          >
+            {cornerLabel}
+          </Text>
+        ) : null}
+      </View>
     </View>
   );
 };

--- a/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
+++ b/mobile/lib/hooks/__tests__/useMealPlanActions.test.ts
@@ -29,6 +29,10 @@ const mockMealPlan = {
   notes: {
     '2026-01-05': 'Office Gym',
   },
+  last_modified_by: {
+    '2026-01-05_lunch': 'test.user@example.com',
+  },
+  extras: {},
 };
 
 const mockRecipes: Recipe[] = [
@@ -121,7 +125,10 @@ describe('useMealPlanActions', () => {
     it('returns recipe when meal value is a known recipe ID', () => {
       const { result } = renderActions();
       const slot = result.current.getMealForSlot(new Date('2026-01-05'), 'lunch');
-      expect(slot).toEqual({ recipe: expect.objectContaining({ id: 'recipe-1', title: 'Chicken Curry' }) });
+      expect(slot).toEqual({
+        recipe: expect.objectContaining({ id: 'recipe-1', title: 'Chicken Curry' }),
+        lastModifiedBy: 'test.user@example.com',
+      });
     });
 
     it('returns customText when meal value starts with "custom:"', () => {

--- a/mobile/lib/hooks/__tests__/useRecipeActions.test.ts
+++ b/mobile/lib/hooks/__tests__/useRecipeActions.test.ts
@@ -14,6 +14,9 @@ const mockRemoveEnhancementMutateAsync = vi.fn();
 const mockCopyMutateAsync = vi.fn();
 const mockRouterBack = vi.fn();
 const mockPickImage = vi.fn();
+const mockUseSettings = vi.fn(() => ({
+  settings: { aiEnabled: true },
+}));
 
 vi.mock('@/lib/hooks', () => ({
   useCurrentUser: vi.fn(() => ({ data: mockCurrentUser() })),
@@ -41,9 +44,7 @@ vi.mock('@/lib/hooks/use-auth', () => ({
 }));
 
 vi.mock('@/lib/settings-context', () => ({
-  useSettings: vi.fn(() => ({
-    settings: { aiEnabled: true },
-  })),
+  useSettings: () => mockUseSettings(),
 }));
 
 vi.mock('expo-router', () => ({
@@ -105,6 +106,7 @@ const makeRecipe = (overrides: Partial<Recipe> = {}): Recipe => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUseSettings.mockReturnValue({ settings: { aiEnabled: true } });
   mockMutateAsync.mockResolvedValue(undefined);
   mockDeleteMutateAsync.mockResolvedValue(undefined);
   mockSetMealMutateAsync.mockResolvedValue(undefined);
@@ -634,6 +636,29 @@ describe('useRecipeActions', () => {
           expect.objectContaining({ text: 'recipe.copyAsIs' }),
           expect.objectContaining({ text: 'recipe.copyAndEnhance' }),
         ]),
+      );
+    });
+
+    it('hides Copy & Enhance when AI is disabled', async () => {
+      mockUseSettings.mockReturnValue({ settings: { aiEnabled: false } });
+      const recipe = makeRecipe({
+        household_id: 'other-household',
+        visibility: 'shared',
+        enhanced: true,
+      });
+      const { result } = renderHook(() => useRecipeActions('recipe-1', recipe), { wrapper });
+      await act(async () => result.current.handleCopyRecipe());
+
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        'recipe.copyEnhancedTitle',
+        'recipe.copyConfirm',
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'common.cancel' }),
+          expect.objectContaining({ text: 'recipe.copyAsIs' }),
+        ]),
+      );
+      expect(mockShowAlert.mock.calls[0][2]).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ text: 'recipe.copyAndEnhance' })]),
       );
     });
 

--- a/mobile/lib/hooks/__tests__/useRecipeActions.test.ts
+++ b/mobile/lib/hooks/__tests__/useRecipeActions.test.ts
@@ -40,6 +40,12 @@ vi.mock('@/lib/hooks/use-auth', () => ({
   })),
 }));
 
+vi.mock('@/lib/settings-context', () => ({
+  useSettings: vi.fn(() => ({
+    settings: { aiEnabled: true },
+  })),
+}));
+
 vi.mock('expo-router', () => ({
   useRouter: vi.fn(() => ({
     push: vi.fn(),
@@ -631,7 +637,7 @@ describe('useRecipeActions', () => {
       );
     });
 
-    it('copies with keepEnhanced=true when choosing Copy As Is', async () => {
+    it('copies the original version when choosing Copy Original', async () => {
       const recipe = makeRecipe({
         household_id: 'other-household',
         visibility: 'shared',
@@ -646,11 +652,11 @@ describe('useRecipeActions', () => {
 
       expect(mockCopyMutateAsync).toHaveBeenCalledWith({
         id: 'recipe-1',
-        keepEnhanced: true,
+        keepEnhanced: false,
       });
     });
 
-    it('copies with keepEnhanced=false when choosing Copy & Enhance', async () => {
+    it('copies the original version and auto-enhances when choosing Copy & Enhance', async () => {
       const recipe = makeRecipe({
         household_id: 'other-household',
         visibility: 'shared',
@@ -667,6 +673,7 @@ describe('useRecipeActions', () => {
         id: 'recipe-1',
         keepEnhanced: false,
       });
+      expect(mockEnhanceMutateAsync).toHaveBeenCalledWith('copied-recipe-1');
     });
 
     it('calls copyRecipe and navigates to copy on success', async () => {

--- a/mobile/lib/hooks/useMealPlanActions.ts
+++ b/mobile/lib/hooks/useMealPlanActions.ts
@@ -135,17 +135,24 @@ export const useMealPlanActions = () => {
     (
       date: Date,
       mealType: MealType,
-    ): { recipe?: Recipe; customText?: string } | null => {
+    ): {
+      recipe?: Recipe;
+      customText?: string;
+      lastModifiedBy?: string;
+    } | null => {
       if (!mealPlan?.meals) return null;
       const dateStr = formatDateLocal(date);
       const key = `${dateStr}_${mealType}`;
       const value = mealPlan.meals[key];
+      const lastModifiedBy = mealPlan.last_modified_by?.[key];
       if (!value) return null;
       if (value.startsWith('custom:')) {
-        return { customText: value.slice(7) };
+        return { customText: value.slice(7), lastModifiedBy };
       }
       const recipe = recipeMap[value];
-      return recipe ? { recipe } : { customText: value };
+      return recipe
+        ? { recipe, lastModifiedBy }
+        : { customText: value, lastModifiedBy };
     },
     [mealPlan, recipeMap],
   );

--- a/mobile/lib/hooks/useRecipeActions.ts
+++ b/mobile/lib/hooks/useRecipeActions.ts
@@ -18,6 +18,7 @@ import {
 import { useHouseholds, useTransferRecipe } from '@/lib/hooks/use-admin';
 import { useAuth } from '@/lib/hooks/use-auth';
 import { useTranslation } from '@/lib/i18n';
+import { useSettings } from '@/lib/settings-context';
 import type {
   DietLabel,
   EnhancementReviewAction,
@@ -46,6 +47,9 @@ export const useRecipeActions = (
   const { user, loading: authLoading } = useAuth();
   const isAuthReady = !authLoading && !!user;
   const { t } = useTranslation();
+  const {
+    settings: { aiEnabled },
+  } = useSettings();
 
   const { data: currentUser } = useCurrentUser({ enabled: isAuthReady });
   const deleteRecipe = useDeleteRecipe();
@@ -397,15 +401,38 @@ export const useRecipeActions = (
   const canCopy = Boolean(!isOwned && isSharedOrLegacy);
   const isCopy = Boolean(recipe?.copied_from);
 
-  const doCopy = async (keepEnhanced: boolean) => {
+  const doCopy = async ({
+    keepEnhanced,
+    autoEnhance = false,
+  }: {
+    keepEnhanced: boolean;
+    autoEnhance?: boolean;
+  }) => {
     if (!id) return;
+
+    let copiedId: string | null = null;
+
     try {
       const copied = await copyRecipe.mutateAsync({ id, keepEnhanced });
+      copiedId = copied.id;
+
+      if (autoEnhance && aiEnabled) {
+        const enhanced = await enhanceRecipe.mutateAsync(copied.id);
+        hapticSuccess();
+        router.replace(`/recipe/${enhanced.id}`);
+        return;
+      }
+
       hapticSuccess();
       showNotification(t('common.success'), t('recipe.copySuccess'));
       router.replace(`/recipe/${copied.id}`);
     } catch {
       hapticWarning();
+      if (copiedId) {
+        router.replace(`/recipe/${copiedId}`);
+        showNotification(t('common.error'), t('recipe.enhanceFailed'));
+        return;
+      }
       showNotification(t('common.error'), t('recipe.copyFailed'));
     }
   };
@@ -421,13 +448,15 @@ export const useRecipeActions = (
           { text: t('common.cancel'), style: 'cancel' },
           {
             text: t('recipe.copyAsIs'),
-            onPress: () => doCopy(true),
+            onPress: () => void doCopy({ keepEnhanced: false }),
           },
           {
             text: t('recipe.copyAndEnhance'),
-            onPress: async () => {
-              await doCopy(false);
-            },
+            onPress: () =>
+              void doCopy({
+                keepEnhanced: false,
+                autoEnhance: true,
+              }),
           },
         ],
       );
@@ -436,7 +465,7 @@ export const useRecipeActions = (
         { text: t('common.cancel'), style: 'cancel' },
         {
           text: t('recipe.copy'),
-          onPress: () => doCopy(false),
+          onPress: () => void doCopy({ keepEnhanced: false }),
         },
       ]);
     }

--- a/mobile/lib/hooks/useRecipeActions.ts
+++ b/mobile/lib/hooks/useRecipeActions.ts
@@ -441,24 +441,29 @@ export const useRecipeActions = (
     if (!id || !recipe) return;
 
     if (recipe.enhanced) {
+      const buttons = [
+        { text: t('common.cancel'), style: 'cancel' as const },
+        {
+          text: t('recipe.copyAsIs'),
+          onPress: () => void doCopy({ keepEnhanced: false }),
+        },
+      ];
+
+      if (aiEnabled) {
+        buttons.push({
+          text: t('recipe.copyAndEnhance'),
+          onPress: () =>
+            void doCopy({
+              keepEnhanced: false,
+              autoEnhance: true,
+            }),
+        });
+      }
+
       showAlert(
         t('recipe.copyEnhancedTitle'),
-        t('recipe.copyEnhancedMessage'),
-        [
-          { text: t('common.cancel'), style: 'cancel' },
-          {
-            text: t('recipe.copyAsIs'),
-            onPress: () => void doCopy({ keepEnhanced: false }),
-          },
-          {
-            text: t('recipe.copyAndEnhance'),
-            onPress: () =>
-              void doCopy({
-                keepEnhanced: false,
-                autoEnhance: true,
-              }),
-          },
-        ],
+        aiEnabled ? t('recipe.copyEnhancedMessage') : t('recipe.copyConfirm'),
+        buttons,
       );
     } else {
       showAlert(t('recipe.copyToHousehold'), t('recipe.copyConfirm'), [

--- a/mobile/lib/i18n/locales/en.ts
+++ b/mobile/lib/i18n/locales/en.ts
@@ -301,9 +301,9 @@ const en = {
       'This will create a private copy in your household. You can then enhance it with your preferences.',
     copyEnhancedTitle: 'Enhanced Recipe',
     copyEnhancedMessage:
-      'This recipe was enhanced for another household. Would you like to re-enhance it for yours?',
+      "This recipe was enhanced for another household's preferences. Copy the original version and enhance it for yours?",
     copyAndEnhance: 'Copy & Enhance',
-    copyAsIs: 'Copy As Is',
+    copyAsIs: 'Copy Original',
     copySuccess: 'Recipe copied to your household',
     copyFailed: 'Failed to copy recipe',
     belongsToAnother: 'Another Household',

--- a/mobile/lib/i18n/locales/it.ts
+++ b/mobile/lib/i18n/locales/it.ts
@@ -303,9 +303,9 @@ const it: Translations = {
       'Verrà creata una copia privata nel tuo nucleo familiare. Potrai poi migliorarla con le tue preferenze.',
     copyEnhancedTitle: 'Ricetta migliorata',
     copyEnhancedMessage:
-      'Questa ricetta è stata migliorata per un altro nucleo familiare. Vuoi migliorarla per il tuo?',
+      'Questa ricetta è stata migliorata per le preferenze di un altro nucleo familiare. Vuoi copiare la versione originale e migliorarla per il tuo?',
     copyAndEnhance: 'Copia e migliora',
-    copyAsIs: "Copia così com'è",
+    copyAsIs: 'Copia originale',
     copySuccess: 'Ricetta copiata nel tuo nucleo familiare',
     copyFailed: 'Impossibile copiare la ricetta',
     belongsToAnother: 'Altro nucleo familiare',

--- a/mobile/lib/i18n/locales/sv.ts
+++ b/mobile/lib/i18n/locales/sv.ts
@@ -296,9 +296,9 @@ const sv: Translations = {
       'Detta skapar en privat kopia i ditt hushåll. Du kan sedan förbättra den med dina preferenser.',
     copyEnhancedTitle: 'Förbättrat recept',
     copyEnhancedMessage:
-      'Det här receptet har förbättrats för ett annat hushåll. Vill du förbättra det för ditt?',
+      'Det här receptet förbättrades för ett annat hushålls preferenser. Vill du kopiera originalversionen och förbättra den för ditt?',
     copyAndEnhance: 'Kopiera & förbättra',
-    copyAsIs: 'Kopiera som det är',
+    copyAsIs: 'Kopiera original',
     copySuccess: 'Receptet kopierat till ditt hushåll',
     copyFailed: 'Kunde inte kopiera receptet',
     belongsToAnother: 'Annat hushåll',

--- a/mobile/lib/types.ts
+++ b/mobile/lib/types.ts
@@ -177,6 +177,7 @@ export interface MealPlan {
   household_id: string;
   meals: Record<string, string>; // date_mealtype -> recipe_id or custom:text
   notes: Record<string, string>; // date -> note text
+  last_modified_by?: Record<string, string>; // date_mealtype -> email of last editor
   extras: Record<string, string[]>; // week start date -> recipe IDs for "Other" section
 }
 

--- a/tests/test_api_grocery.py
+++ b/tests/test_api_grocery.py
@@ -57,7 +57,7 @@ class TestGenerateGroceryList:
 
     def test_generate_empty_meal_plan(self, client: TestClient) -> None:
         """Should return empty list for empty meal plan."""
-        with patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=({}, {}, [])):
+        with patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})):
             response = client.get("/grocery")
 
         assert response.status_code == 200
@@ -75,7 +75,7 @@ class TestGenerateGroceryList:
         """Should include custom meals as simple grocery items."""
         meals = {"2025-01-15_lunch": "custom:Eating out"}
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery._get_today", return_value=date(2025, 1, 15)),
         ):
             response = client.get("/grocery")
@@ -95,7 +95,7 @@ class TestGenerateGroceryList:
         mock_recipe.title = "Test Recipe"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={"recipe123": mock_recipe}),
             patch("api.routers.grocery._get_today", return_value=date(2025, 1, 15)),
         ):
@@ -118,7 +118,7 @@ class TestGenerateGroceryList:
         mock_recipe2.title = "Recipe 2"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch(
                 "api.routers.grocery.get_recipes_by_ids",
                 return_value={"recipe1": mock_recipe1, "recipe2": mock_recipe2},
@@ -145,7 +145,7 @@ class TestGenerateGroceryList:
         mock_recipe.title = "Test Recipe"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={"recipe1": mock_recipe}) as mock_batch,
         ):
             response = client.get("/grocery?start_date=2025-01-14&end_date=2025-01-16")
@@ -163,7 +163,7 @@ class TestGenerateGroceryList:
         mock_recipe.title = "Good Recipe"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={"recipe2": mock_recipe}),
             patch("api.routers.grocery._get_today", return_value=date(2025, 1, 15)),
         ):
@@ -177,7 +177,7 @@ class TestGenerateGroceryList:
         meals = {"notadate_dinner": "recipe1"}
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={}),
             patch("api.routers.grocery._get_today", return_value=date(2025, 1, 15)),
         ):
@@ -194,7 +194,10 @@ class TestGenerateGroceryList:
         mock_recipe.title = "Extra Recipe"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=({}, {}, ["extra1"])),
+            patch(
+                "api.routers.grocery.meal_plan_storage.load_meal_plan",
+                return_value=({}, {}, {}, {"2025-01-13": ["extra1"]}),
+            ),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={"extra1": mock_recipe}),
         ):
             response = client.get("/grocery")
@@ -207,7 +210,7 @@ class TestGenerateGroceryList:
         meals = {"2025-01-15_dinner": "missing_recipe"}
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={}),
             patch("api.routers.grocery._get_today", return_value=date(2025, 1, 15)),
         ):
@@ -232,7 +235,7 @@ class TestGenerateGroceryList:
         foreign_recipe.title = "Foreign"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch(
                 "api.routers.grocery.get_recipes_by_ids",
                 return_value={"owned": owned_recipe, "foreign": foreign_recipe},
@@ -256,7 +259,7 @@ class TestGenerateGroceryList:
         shared_recipe.title = "Shared Recipe"
 
         with (
-            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, [])),
+            patch("api.routers.grocery.meal_plan_storage.load_meal_plan", return_value=(meals, {}, {}, {})),
             patch("api.routers.grocery.get_recipes_by_ids", return_value={"shared_recipe": shared_recipe}),
             patch("api.routers.grocery._get_today", return_value=date(2025, 1, 15)),
         ):

--- a/tests/test_api_meal_plan.py
+++ b/tests/test_api_meal_plan.py
@@ -114,16 +114,16 @@ class TestMealPlan:
         plan = MealPlan(
             household_id="household1",
             meals={"2025-01-15_dinner": "recipe1"},
-            last_modified_by={"2025-01-15_dinner": "cook@example.com"},
+            last_modified_by={"2025-01-15_dinner": "CB"},
         )
-        assert plan.last_modified_by["2025-01-15_dinner"] == "cook@example.com"
+        assert plan.last_modified_by["2025-01-15_dinner"] == "CB"
 
     def test_get_meals_for_day_includes_last_modified_by(self) -> None:
         """Should expose slot attribution on planned meals."""
         plan = MealPlan(
             household_id="household1",
             meals={"2025-01-15_dinner": "recipe1"},
-            last_modified_by={"2025-01-15_dinner": "cook@example.com"},
+            last_modified_by={"2025-01-15_dinner": "CB"},
         )
         meals = plan.get_meals_for_day(date(2025, 1, 15))
-        assert meals[0].last_modified_by == "cook@example.com"
+        assert meals[0].last_modified_by == "CB"

--- a/tests/test_api_meal_plan.py
+++ b/tests/test_api_meal_plan.py
@@ -43,6 +43,7 @@ class TestMealPlan:
         assert plan.household_id == "household1"
         assert plan.meals == {}
         assert plan.notes == {}
+        assert plan.last_modified_by == {}
 
     def test_meal_plan_with_meals(self) -> None:
         """Should store meals in correct format."""
@@ -107,3 +108,22 @@ class TestMealPlan:
         plan = MealPlan(household_id="household1", notes={"2025-01-15": "Work from home", "2025-01-16": "Office day"})
         assert plan.notes["2025-01-15"] == "Work from home"
         assert plan.notes["2025-01-16"] == "Office day"
+
+    def test_last_modified_by_storage(self) -> None:
+        """Should store slot attribution by meal key."""
+        plan = MealPlan(
+            household_id="household1",
+            meals={"2025-01-15_dinner": "recipe1"},
+            last_modified_by={"2025-01-15_dinner": "cook@example.com"},
+        )
+        assert plan.last_modified_by["2025-01-15_dinner"] == "cook@example.com"
+
+    def test_get_meals_for_day_includes_last_modified_by(self) -> None:
+        """Should expose slot attribution on planned meals."""
+        plan = MealPlan(
+            household_id="household1",
+            meals={"2025-01-15_dinner": "recipe1"},
+            last_modified_by={"2025-01-15_dinner": "cook@example.com"},
+        )
+        meals = plan.get_meals_for_day(date(2025, 1, 15))
+        assert meals[0].last_modified_by == "cook@example.com"

--- a/tests/test_api_meal_plans.py
+++ b/tests/test_api_meal_plans.py
@@ -37,7 +37,7 @@ class TestGetMealPlan:
 
     def test_get_empty_meal_plan(self, client: TestClient) -> None:
         """Should return empty meal plan for new household."""
-        with patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})):
+        with patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})):
             response = client.get("/meal-plans")
 
         assert response.status_code == 200
@@ -45,12 +45,16 @@ class TestGetMealPlan:
         assert data["household_id"] == "test_household"
         assert data["meals"] == {}
         assert data["notes"] == {}
+        assert data["last_modified_by"] == {}
 
     def test_get_meal_plan_with_meals(self, client: TestClient) -> None:
         """Should return meal plan with existing meals."""
         meals = {"2025-01-15_lunch": "recipe123", "2025-01-15_dinner": "custom:Pizza"}
         notes = {"2025-01-15": "office day"}
-        with patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=(meals, notes, {})):
+        last_modified_by = {"2025-01-15_lunch": "chef@example.com"}
+        with patch(
+            "api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=(meals, notes, last_modified_by, {})
+        ):
             response = client.get("/meal-plans")
 
         assert response.status_code == 200
@@ -58,6 +62,7 @@ class TestGetMealPlan:
         assert data["meals"]["2025-01-15_lunch"] == "recipe123"
         assert data["meals"]["2025-01-15_dinner"] == "custom:Pizza"
         assert data["notes"]["2025-01-15"] == "office day"
+        assert data["last_modified_by"]["2025-01-15_lunch"] == "chef@example.com"
 
     def test_get_meal_plan_superuser_requires_household_id(self, client_no_household: TestClient) -> None:
         """Superuser without household must specify household_id parameter."""
@@ -68,7 +73,7 @@ class TestGetMealPlan:
 
     def test_get_meal_plan_superuser_with_household_id(self, client_no_household: TestClient) -> None:
         """Superuser can access any household by specifying household_id."""
-        with patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})):
+        with patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})):
             response = client_no_household.get("/meal-plans?household_id=test-household")
 
             assert response.status_code == 200
@@ -92,19 +97,19 @@ class TestUpdateMealPlan:
             patch("api.routers.meal_plans.meal_plan_storage.update_meal") as mock_update,
             patch(
                 "api.routers.meal_plans.meal_plan_storage.load_meal_plan",
-                return_value=({"2025-01-15_lunch": "recipe123"}, {}, {}),
+                return_value=({"2025-01-15_lunch": "recipe123"}, {}, {"2025-01-15_lunch": "user@example.com"}, {}),
             ),
         ):
             response = client.put("/meal-plans", json={"meals": {"2025-01-15_lunch": "recipe123"}, "notes": {}})
 
         assert response.status_code == 200
-        mock_update.assert_called_once_with("test_household", "2025-01-15", "lunch", "recipe123")
+        mock_update.assert_called_once_with("test_household", "2025-01-15", "lunch", "recipe123", "test@example.com")
 
     def test_update_delete_meal(self, client: TestClient) -> None:
         """Should delete meal when value is None."""
         with (
             patch("api.routers.meal_plans.meal_plan_storage.delete_meal") as mock_delete,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})),
         ):
             response = client.put("/meal-plans", json={"meals": {"2025-01-15_lunch": None}, "notes": {}})
 
@@ -124,7 +129,7 @@ class TestUpdateMealPlan:
             patch("api.routers.meal_plans.meal_plan_storage.update_day_note") as mock_note,
             patch(
                 "api.routers.meal_plans.meal_plan_storage.load_meal_plan",
-                return_value=({}, {"2025-01-15": "work from home"}, {}),
+                return_value=({}, {"2025-01-15": "work from home"}, {}, {}),
             ),
         ):
             response = client.put("/meal-plans", json={"meals": {}, "notes": {"2025-01-15": "work from home"}})
@@ -137,7 +142,7 @@ class TestUpdateMealPlan:
         extras = {"2025-01-13": ["recipe1", "recipe2"]}
         with (
             patch("api.routers.meal_plans.meal_plan_storage.update_extras") as mock_extras,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, extras)),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, extras)),
         ):
             response = client.put("/meal-plans", json={"meals": {}, "notes": {}, "extras": extras})
 
@@ -153,20 +158,20 @@ class TestUpdateSingleMeal:
         """Should update a single meal."""
         with (
             patch("api.routers.meal_plans.meal_plan_storage.update_meal") as mock_update,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})),
         ):
             response = client.post(
                 "/meal-plans/meals", json={"date": "2025-01-15", "meal_type": "dinner", "value": "recipe456"}
             )
 
         assert response.status_code == 200
-        mock_update.assert_called_once_with("test_household", "2025-01-15", "dinner", "recipe456")
+        mock_update.assert_called_once_with("test_household", "2025-01-15", "dinner", "recipe456", "test@example.com")
 
     def test_delete_single_meal(self, client: TestClient) -> None:
         """Should delete meal when value is None."""
         with (
             patch("api.routers.meal_plans.meal_plan_storage.delete_meal") as mock_delete,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})),
         ):
             response = client.post(
                 "/meal-plans/meals", json={"date": "2025-01-15", "meal_type": "dinner", "value": None}
@@ -191,7 +196,7 @@ class TestUpdateSingleNote:
         """Should update a single note."""
         with (
             patch("api.routers.meal_plans.meal_plan_storage.update_day_note") as mock_note,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})),
         ):
             response = client.post("/meal-plans/notes", json={"date": "2025-01-15", "note": "busy day"})
 
@@ -214,7 +219,7 @@ class TestClearMealPlan:
             response = client.delete("/meal-plans")
 
         assert response.status_code == 204
-        mock_save.assert_called_once_with("test_household", {}, {}, {})
+        mock_save.assert_called_once_with("test_household", {}, {}, {}, {})
 
 
 class TestUpdateExtras:
@@ -226,7 +231,7 @@ class TestUpdateExtras:
         week = "2025-01-13"
         with (
             patch("api.routers.meal_plans.meal_plan_storage.update_extras") as mock_update,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {week: extras})),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {week: extras})),
         ):
             response = client.post("/meal-plans/extras", json={"week": week, "extras": extras})
 
@@ -240,7 +245,7 @@ class TestUpdateExtras:
         week = "2025-01-13"
         with (
             patch("api.routers.meal_plans.meal_plan_storage.update_extras") as mock_update,
-            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {})),
+            patch("api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=({}, {}, {}, {})),
         ):
             response = client.post("/meal-plans/extras", json={"week": week, "extras": []})
 

--- a/tests/test_api_meal_plans.py
+++ b/tests/test_api_meal_plans.py
@@ -51,7 +51,7 @@ class TestGetMealPlan:
         """Should return meal plan with existing meals."""
         meals = {"2025-01-15_lunch": "recipe123", "2025-01-15_dinner": "custom:Pizza"}
         notes = {"2025-01-15": "office day"}
-        last_modified_by = {"2025-01-15_lunch": "chef@example.com"}
+        last_modified_by = {"2025-01-15_lunch": "CE"}
         with patch(
             "api.routers.meal_plans.meal_plan_storage.load_meal_plan", return_value=(meals, notes, last_modified_by, {})
         ):
@@ -62,7 +62,7 @@ class TestGetMealPlan:
         assert data["meals"]["2025-01-15_lunch"] == "recipe123"
         assert data["meals"]["2025-01-15_dinner"] == "custom:Pizza"
         assert data["notes"]["2025-01-15"] == "office day"
-        assert data["last_modified_by"]["2025-01-15_lunch"] == "chef@example.com"
+        assert data["last_modified_by"]["2025-01-15_lunch"] == "CE"
 
     def test_get_meal_plan_superuser_requires_household_id(self, client_no_household: TestClient) -> None:
         """Superuser without household must specify household_id parameter."""
@@ -97,13 +97,13 @@ class TestUpdateMealPlan:
             patch("api.routers.meal_plans.meal_plan_storage.update_meal") as mock_update,
             patch(
                 "api.routers.meal_plans.meal_plan_storage.load_meal_plan",
-                return_value=({"2025-01-15_lunch": "recipe123"}, {}, {"2025-01-15_lunch": "user@example.com"}, {}),
+                return_value=({"2025-01-15_lunch": "recipe123"}, {}, {"2025-01-15_lunch": "TE"}, {}),
             ),
         ):
             response = client.put("/meal-plans", json={"meals": {"2025-01-15_lunch": "recipe123"}, "notes": {}})
 
         assert response.status_code == 200
-        mock_update.assert_called_once_with("test_household", "2025-01-15", "lunch", "recipe123", "test@example.com")
+        mock_update.assert_called_once_with("test_household", "2025-01-15", "lunch", "recipe123", "TE")
 
     def test_update_delete_meal(self, client: TestClient) -> None:
         """Should delete meal when value is None."""
@@ -165,7 +165,7 @@ class TestUpdateSingleMeal:
             )
 
         assert response.status_code == 200
-        mock_update.assert_called_once_with("test_household", "2025-01-15", "dinner", "recipe456", "test@example.com")
+        mock_update.assert_called_once_with("test_household", "2025-01-15", "dinner", "recipe456", "TE")
 
     def test_delete_single_meal(self, client: TestClient) -> None:
         """Should delete meal when value is None."""


### PR DESCRIPTION
## Summary
- default shared enhanced recipe copies back to the original scraped version and optionally auto-enhance for the destination household
- track who last changed each meal-plan slot and show light grey initials in the slot UI
- stack 3-button alerts vertically on narrow screens for the shared recipe copy flow

## Testing
- uv run pytest tests/test_api_meal_plan.py tests/test_api_meal_plans.py
- cd mobile && pnpm vitest run components/__tests__/themedalert-layout.test.ts lib/hooks/__tests__/useMealPlanActions.test.ts lib/hooks/__tests__/useRecipeActions.test.ts
