### PR TITLE
feat: set Petrol as default theme, restrict appearance to superusers

### DIFF
--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -37,6 +37,7 @@ export default function SettingsScreen() {
   const { data: currentUser, isLoading: userLoading } = useCurrentUser();
   const { settings, toggleShowHiddenRecipes } = useSettings();
   const { t } = useTranslation();
+  const canManageAppearance = currentUser?.role === 'superuser';
 
   const householdId = currentUser?.household_id;
   const hasHousehold = !!householdId;
@@ -93,6 +94,7 @@ export default function SettingsScreen() {
               <PersonalPreferencesSection
                 showHiddenRecipes={settings.showHiddenRecipes}
                 onToggleShowHidden={toggleShowHiddenRecipes}
+                canManageAppearance={canManageAppearance}
               />
             </Section>
           </View>

--- a/mobile/app/__tests__/settings.test.tsx
+++ b/mobile/app/__tests__/settings.test.tsx
@@ -106,6 +106,69 @@ describe('Settings screen', () => {
 
       expect(mockPush).not.toHaveBeenCalled();
     });
+
+    it('hides appearance settings for members', async () => {
+      mockCurrentUserData = {
+        uid: 'user-4',
+        email: 'member@example.com',
+        role: 'member',
+        household_id: 'household-abc',
+        household_name: 'Test House',
+      };
+
+      const { default: SettingsScreen } = await import('@/app/(tabs)/settings');
+      const Wrapper = createQueryWrapper();
+
+      render(
+        React.createElement(Wrapper, null,
+          React.createElement(SettingsScreen)
+        ),
+      );
+
+      expect(screen.queryByText('Appearance')).toBeNull();
+    });
+
+    it('hides appearance settings for admins', async () => {
+      mockCurrentUserData = {
+        uid: 'user-5',
+        email: 'admin@example.com',
+        role: 'admin',
+        household_id: 'household-abc',
+        household_name: 'Test House',
+      };
+
+      const { default: SettingsScreen } = await import('@/app/(tabs)/settings');
+      const Wrapper = createQueryWrapper();
+
+      render(
+        React.createElement(Wrapper, null,
+          React.createElement(SettingsScreen)
+        ),
+      );
+
+        expect(screen.queryByText('Appearance')).toBeNull();
+      });
+
+      it('shows appearance settings for superusers', async () => {
+        mockCurrentUserData = {
+          uid: 'user-6',
+          email: 'superuser@example.com',
+          role: 'superuser',
+          household_id: 'household-abc',
+          household_name: 'Test House',
+        };
+
+        const { default: SettingsScreen } = await import('@/app/(tabs)/settings');
+        const Wrapper = createQueryWrapper();
+
+        render(
+          React.createElement(Wrapper, null,
+            React.createElement(SettingsScreen)
+          ),
+        );
+
+        expect(screen.getByText('Appearance')).toBeTruthy();
+    });
   });
 
   describe('AI settings navigation', () => {

--- a/mobile/app/__tests__/settings.test.tsx
+++ b/mobile/app/__tests__/settings.test.tsx
@@ -125,7 +125,7 @@ describe('Settings screen', () => {
         ),
       );
 
-      expect(screen.queryByText('Appearance')).toBeNull();
+      expect(screen.queryByTestId('appearance-section')).toBeNull();
     });
 
     it('hides appearance settings for admins', async () => {
@@ -146,28 +146,28 @@ describe('Settings screen', () => {
         ),
       );
 
-        expect(screen.queryByText('Appearance')).toBeNull();
-      });
+      expect(screen.queryByTestId('appearance-section')).toBeNull();
+    });
 
-      it('shows appearance settings for superusers', async () => {
-        mockCurrentUserData = {
-          uid: 'user-6',
-          email: 'superuser@example.com',
-          role: 'superuser',
-          household_id: 'household-abc',
-          household_name: 'Test House',
-        };
+    it('shows appearance settings for superusers', async () => {
+      mockCurrentUserData = {
+        uid: 'user-6',
+        email: 'superuser@example.com',
+        role: 'superuser',
+        household_id: 'household-abc',
+        household_name: 'Test House',
+      };
 
-        const { default: SettingsScreen } = await import('@/app/(tabs)/settings');
-        const Wrapper = createQueryWrapper();
+      const { default: SettingsScreen } = await import('@/app/(tabs)/settings');
+      const Wrapper = createQueryWrapper();
 
-        render(
-          React.createElement(Wrapper, null,
-            React.createElement(SettingsScreen)
-          ),
-        );
+      render(
+        React.createElement(Wrapper, null,
+          React.createElement(SettingsScreen)
+        ),
+      );
 
-        expect(screen.getByText('Appearance')).toBeTruthy();
+      expect(screen.getByTestId('appearance-section')).toBeTruthy();
     });
   });
 

--- a/mobile/components/settings/PreferencesSection.tsx
+++ b/mobile/components/settings/PreferencesSection.tsx
@@ -9,11 +9,13 @@ import { ThemePicker } from './ThemePicker';
 interface PersonalPreferencesSectionProps {
   showHiddenRecipes: boolean;
   onToggleShowHidden: () => void;
+  canManageAppearance: boolean;
 }
 
 export const PersonalPreferencesSection = ({
   showHiddenRecipes,
   onToggleShowHidden,
+  canManageAppearance,
 }: PersonalPreferencesSectionProps) => {
   const { colors, fonts, themeName, setThemeName } = useTheme();
   const { t } = useTranslation();
@@ -27,19 +29,21 @@ export const PersonalPreferencesSection = ({
         onValueChange={onToggleShowHidden}
       />
 
-      <View style={{ marginTop: spacing.lg }}>
-        <Text
-          style={{
-            fontFamily: fonts.bodySemibold,
-            fontSize: fontSize.sm,
-            color: colors.content.strong,
-            marginBottom: spacing.xs,
-          }}
-        >
-          {t('settings.appearance')}
-        </Text>
-        <ThemePicker currentTheme={themeName} onChangeTheme={setThemeName} />
-      </View>
+      {canManageAppearance ? (
+        <View style={{ marginTop: spacing.lg }}>
+          <Text
+            style={{
+              fontFamily: fonts.bodySemibold,
+              fontSize: fontSize.sm,
+              color: colors.content.strong,
+              marginBottom: spacing.xs,
+            }}
+          >
+            {t('settings.appearance')}
+          </Text>
+          <ThemePicker currentTheme={themeName} onChangeTheme={setThemeName} />
+        </View>
+      ) : null}
     </View>
   );
 };

--- a/mobile/components/settings/PreferencesSection.tsx
+++ b/mobile/components/settings/PreferencesSection.tsx
@@ -30,7 +30,7 @@ export const PersonalPreferencesSection = ({
       />
 
       {canManageAppearance ? (
-        <View style={{ marginTop: spacing.lg }}>
+        <View testID="appearance-section" style={{ marginTop: spacing.lg }}>
           <Text
             style={{
               fontFamily: fonts.bodySemibold,

--- a/mobile/lib/theme/themes/index.ts
+++ b/mobile/lib/theme/themes/index.ts
@@ -18,8 +18,8 @@ import { terminalTheme } from './terminal';
 // ── Theme list — first entry is the default ────────────────────────────
 
 const allThemes: ThemeDefinition[] = [
-  lightTheme,
   petrolTheme,
+  lightTheme,
   terminalTheme,
   bubblegumTheme,
 ];


### PR DESCRIPTION
## Summary

- Set **Petrol** as the default theme for new/first-time users (first entry in theme registry)
- Restrict the appearance/theme picker in Settings to **superusers only** (was previously available to all roles)

## Changes

- `mobile/lib/theme/themes/index.ts` — moved `petrolTheme` to first position in `allThemes`
- `mobile/app/(tabs)/settings.tsx` — `canManageAppearance` now gated to `role === 'superuser'`
- `mobile/components/settings/PreferencesSection.tsx` — new required `canManageAppearance` prop; `ThemePicker` only renders when true
- `mobile/app/__tests__/settings.test.tsx` — 3 new tests covering member-hides, admin-hides, superuser-shows appearance section

## Testing

All 7 settings screen tests pass.