### PR TITLE
fix: improve grocery hidden item handling

### DIFF
--- a/mobile/app/(tabs)/grocery.tsx
+++ b/mobile/app/(tabs)/grocery.tsx
@@ -33,6 +33,7 @@ export default function GroceryScreen() {
     setNewItemText,
     totalItems,
     hiddenAtHomeCount,
+    hiddenAtHomeItems,
     itemsToBuy,
     checkedItemsToBuy,
     uncheckedItems,
@@ -94,6 +95,7 @@ export default function GroceryScreen() {
             checkedItemsToBuy={checkedItemsToBuy}
             totalItems={totalItems}
             hiddenAtHomeCount={hiddenAtHomeCount}
+            hiddenAtHomeItems={hiddenAtHomeItems}
             showAddItem={showAddItem}
             deleteMode={deleteMode}
             reorderMode={reorderMode}

--- a/mobile/components/__tests__/StatsCard.test.tsx
+++ b/mobile/components/__tests__/StatsCard.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { StatsCard } from '../grocery/StatsCard';
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      if (key === 'grocery.hiddenAtHome') {
+        return `${params?.count} item(s) hidden (at home)`;
+      }
+      if (key === 'grocery.hiddenAtHomeDetails') {
+        return `Hidden items:\n\n${params?.items}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+describe('StatsCard', () => {
+  it('shows hidden generated items in the help popup', () => {
+    render(
+      <StatsCard
+        itemsToBuy={3}
+        checkedItemsToBuy={1}
+        totalItems={4}
+        hiddenAtHomeCount={2}
+        hiddenAtHomeItems={['grön sparris', 'pepparrot']}
+        showAddItem={false}
+        deleteMode={false}
+        reorderMode={false}
+        deleteSelection={new Set()}
+        mealPlanItemNames={[]}
+        manualItemNames={[]}
+        onToggleAddItem={vi.fn()}
+        onToggleDeleteMode={vi.fn()}
+        onToggleReorderMode={vi.fn()}
+        onSelectionChange={vi.fn()}
+        onDeleteSelected={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('help-tip-toggle'));
+
+    expect(screen.getByText(/Hidden items:/)).toBeDefined();
+    expect(screen.getByText(/grön sparris/)).toBeDefined();
+    expect(screen.getByText(/pepparrot/)).toBeDefined();
+  });
+});

--- a/mobile/components/grocery/StatsCard.tsx
+++ b/mobile/components/grocery/StatsCard.tsx
@@ -1,10 +1,8 @@
-import { useRouter } from 'expo-router';
 import { Text, View } from 'react-native';
-import { AnimatedPressable } from '@/components/AnimatedPressable';
 import { ButtonGroup } from '@/components/ButtonGroup';
+import { HelpTipIcon } from '@/components/HelpTip';
 import { IconButton } from '@/components/IconButton';
 import { ThemeIcon } from '@/components/ThemeIcon';
-import { useCurrentUser } from '@/lib/hooks/use-admin';
 import { useTranslation } from '@/lib/i18n';
 import { fontSize, fontWeight, iconSize, spacing, useTheme } from '@/lib/theme';
 import { ClearMenu } from './ClearMenu';
@@ -117,36 +115,24 @@ const ProgressBar = ({ itemsToBuy, checkedItemsToBuy }: ProgressBarProps) => {
 
 interface ItemsAtHomeIndicatorProps {
   hiddenAtHomeCount: number;
+  hiddenAtHomeItems: string[];
 }
 
 const ItemsAtHomeIndicator = ({
   hiddenAtHomeCount,
+  hiddenAtHomeItems,
 }: ItemsAtHomeIndicatorProps) => {
   const { colors, fonts, borderRadius } = useTheme();
-  const router = useRouter();
   const { t } = useTranslation();
-  const { data: currentUser } = useCurrentUser();
-  const householdId = currentUser?.household_id;
 
   if (hiddenAtHomeCount <= 0) return null;
 
-  const onPress = () => {
-    if (householdId) {
-      router.push(`/household-settings?id=${householdId}&section=pantry`);
-    } else {
-      router.push('/settings');
-    }
-  };
+  const hiddenItemsText = hiddenAtHomeItems
+    .map((item) => `• ${item}`)
+    .join('\n');
 
   return (
-    <AnimatedPressable
-      onPress={onPress}
-      hoverScale={1.02}
-      pressScale={0.98}
-      accessibilityRole="button"
-      accessibilityLabel={t('grocery.hiddenAtHome', {
-        count: hiddenAtHomeCount,
-      })}
+    <View
       style={{
         flexDirection: 'row',
         alignItems: 'center',
@@ -174,12 +160,12 @@ const ItemsAtHomeIndicator = ({
       >
         {t('grocery.hiddenAtHome', { count: hiddenAtHomeCount })}
       </Text>
-      <ThemeIcon
-        name="chevron-forward"
-        size={iconSize.xs}
-        color={colors.content.subtitle}
+      <HelpTipIcon
+        helpText={t('grocery.hiddenAtHomeDetails', {
+          items: hiddenItemsText,
+        })}
       />
-    </AnimatedPressable>
+    </View>
   );
 };
 
@@ -188,6 +174,7 @@ interface StatsCardProps {
   checkedItemsToBuy: number;
   totalItems: number;
   hiddenAtHomeCount: number;
+  hiddenAtHomeItems: string[];
   showAddItem: boolean;
   deleteMode: boolean;
   reorderMode: boolean;
@@ -206,6 +193,7 @@ export const StatsCard = ({
   checkedItemsToBuy,
   totalItems,
   hiddenAtHomeCount,
+  hiddenAtHomeItems,
   showAddItem,
   deleteMode,
   reorderMode,
@@ -292,7 +280,10 @@ export const StatsCard = ({
         />
       )}
 
-      <ItemsAtHomeIndicator hiddenAtHomeCount={hiddenAtHomeCount} />
+      <ItemsAtHomeIndicator
+        hiddenAtHomeCount={hiddenAtHomeCount}
+        hiddenAtHomeItems={hiddenAtHomeItems}
+      />
     </View>
   );
 };

--- a/mobile/lib/__tests__/settings-context.test.tsx
+++ b/mobile/lib/__tests__/settings-context.test.tsx
@@ -297,7 +297,7 @@ describe('SettingsProvider', () => {
       expect(result.current.isItemAtHome('salt')).toBe(true);
     });
 
-    it('matches when grocery item contains a home item', async () => {
+    it('matches after normalizing case and whitespace', async () => {
       mockItemsAtHome = ['salt'];
 
       const { result } = renderHook(() => useSettings(), {
@@ -305,18 +305,19 @@ describe('SettingsProvider', () => {
       });
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.isItemAtHome('sea salt')).toBe(true);
+      expect(result.current.isItemAtHome('  SALT  ')).toBe(true);
     });
 
-    it('matches when home item contains the grocery item', async () => {
-      mockItemsAtHome = ['olive oil'];
+    it('returns false for partial matches', async () => {
+      mockItemsAtHome = ['salt', 'olive oil'];
 
       const { result } = renderHook(() => useSettings(), {
         wrapper: createSettingsWrapper(),
       });
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.isItemAtHome('oil')).toBe(true);
+      expect(result.current.isItemAtHome('sea salt')).toBe(false);
+      expect(result.current.isItemAtHome('oil')).toBe(false);
     });
 
     it('returns false for non-matching item', async () => {

--- a/mobile/lib/hooks/__tests__/useGroceryScreen.test.ts
+++ b/mobile/lib/hooks/__tests__/useGroceryScreen.test.ts
@@ -1136,6 +1136,19 @@ describe('useGroceryScreen', () => {
       expect(result.current.hiddenAtHomeCount).toBe(1);
     });
 
+    it('hiddenAtHomeItems only includes generated items that are at home', async () => {
+      await mockSettingsWithItemAtHome((name) => name === 'salt' || name === 'pepper');
+      setupMealPlanWithSalt();
+      mockContextState.customItems = [
+        { name: 'salt', category: 'pantry' },
+        { name: 'pepper', category: 'pantry' },
+      ];
+
+      const { result } = renderHook(() => useGroceryScreen());
+
+      expect(result.current.hiddenAtHomeItems).toEqual(['salt']);
+    });
+
     it('checkedItemsToBuy includes checked manual items even if they match items at home', async () => {
       await mockSettingsWithItemAtHome((name) => name === 'salt');
 

--- a/mobile/lib/hooks/useGroceryScreen.ts
+++ b/mobile/lib/hooks/useGroceryScreen.ts
@@ -438,17 +438,17 @@ export const useGroceryScreen = () => {
   const checkedCount = checkedItems.size;
 
   const hiddenAtHomeCount = useMemo(
-    () => groceryListWithChecked.items.filter(isGeneratedItemAtHome).length,
-    [groceryListWithChecked.items, isGeneratedItemAtHome],
+    () => visibleGeneratedItems.filter(isGeneratedItemAtHome).length,
+    [visibleGeneratedItems, isGeneratedItemAtHome],
   );
 
   const hiddenAtHomeItems = useMemo(
     () =>
-      groceryListWithChecked.items
+      visibleGeneratedItems
         .filter(isGeneratedItemAtHome)
         .map((item) => item.name)
         .sort((left, right) => left.localeCompare(right)),
-    [groceryListWithChecked.items, isGeneratedItemAtHome],
+    [visibleGeneratedItems, isGeneratedItemAtHome],
   );
 
   const itemsToBuy = totalItems - hiddenAtHomeCount;

--- a/mobile/lib/hooks/useGroceryScreen.ts
+++ b/mobile/lib/hooks/useGroceryScreen.ts
@@ -442,6 +442,15 @@ export const useGroceryScreen = () => {
     [groceryListWithChecked.items, isGeneratedItemAtHome],
   );
 
+  const hiddenAtHomeItems = useMemo(
+    () =>
+      groceryListWithChecked.items
+        .filter(isGeneratedItemAtHome)
+        .map((item) => item.name)
+        .sort((left, right) => left.localeCompare(right)),
+    [groceryListWithChecked.items, isGeneratedItemAtHome],
+  );
+
   const itemsToBuy = totalItems - hiddenAtHomeCount;
 
   const checkedItemsToBuy = useMemo(
@@ -474,6 +483,7 @@ export const useGroceryScreen = () => {
     totalItems,
     checkedCount,
     hiddenAtHomeCount,
+    hiddenAtHomeItems,
     itemsToBuy,
     checkedItemsToBuy,
     uncheckedItems,

--- a/mobile/lib/i18n/locales/en.ts
+++ b/mobile/lib/i18n/locales/en.ts
@@ -450,6 +450,8 @@ const en = {
     itemsSelected: '{{count}} selected',
     dragToReorder: 'Drag to reorder',
     hiddenAtHome: '{{count}} item(s) hidden (at home)',
+    hiddenAtHomeDetails:
+      'These recipe items are hidden because they are marked under Items at Home:\n\n{{items}}\n\nManually added items stay visible.',
     addItemPlaceholder: 'Add an item...',
     addButton: 'Add',
     allStores: 'None',

--- a/mobile/lib/i18n/locales/it.ts
+++ b/mobile/lib/i18n/locales/it.ts
@@ -449,6 +449,8 @@ const it: Translations = {
     itemsSelected: '{{count}} selezionati',
     dragToReorder: 'Trascina per riordinare',
     hiddenAtHome: '{{count}} articolo/i nascosti (a casa)',
+    hiddenAtHomeDetails:
+      'Questi articoli delle ricette sono nascosti perché segnati in Articoli a casa:\n\n{{items}}\n\nGli articoli aggiunti manualmente restano visibili.',
     addItemPlaceholder: 'Aggiungi un articolo...',
     addButton: 'Aggiungi',
     allStores: 'Nessuno',

--- a/mobile/lib/i18n/locales/sv.ts
+++ b/mobile/lib/i18n/locales/sv.ts
@@ -441,6 +441,8 @@ const sv: Translations = {
     itemsSelected: '{{count}} valda',
     dragToReorder: 'Dra för att sortera',
     hiddenAtHome: '{{count}} vara/varor dolda (finns hemma)',
+    hiddenAtHomeDetails:
+      'Dessa receptvaror är dolda eftersom de är markerade under Varor hemma:\n\n{{items}}\n\nVaror som lagts till manuellt visas fortfarande.',
     addItemPlaceholder: 'Lägg till en vara...',
     addButton: 'Lägg till',
     allStores: 'Ingen',

--- a/mobile/lib/settings-context.tsx
+++ b/mobile/lib/settings-context.tsx
@@ -268,9 +268,7 @@ export const SettingsProvider = ({
     (item: string) => {
       const normalizedItem = item.toLowerCase().trim();
       return settings.itemsAtHome.some(
-        (homeItem) =>
-          normalizedItem.includes(homeItem) ||
-          homeItem.includes(normalizedItem),
+        (homeItem) => homeItem === normalizedItem,
       );
     },
     [settings.itemsAtHome],

--- a/mobile/lib/utils/__tests__/groceryAggregator.test.ts
+++ b/mobile/lib/utils/__tests__/groceryAggregator.test.ts
@@ -144,6 +144,27 @@ describe('aggregateIngredients', () => {
     expect(result[0].name).toBe('cream');
   });
 
+  it('keeps garnish ingredients when stripping trailing serving notes', () => {
+    const recipes = [
+      makeRecipe({
+        id: 'r1',
+        title: 'Laxpudding',
+        ingredients: [
+          '1 knippe grön sparris till servering',
+          '2 msk riven pepparrot till servering',
+        ],
+        servings: 4,
+      }),
+    ];
+    const meals = { 'mon-lunch': 'r1' };
+    const result = aggregateIngredients(['mon-lunch'], meals, recipes, {});
+
+    expect(result.map((item) => item.name)).toEqual([
+      'grön sparris',
+      'riven pepparrot',
+    ]);
+  });
+
   it('does not merge ingredients with different units', () => {
     const recipes = [
       makeRecipe({

--- a/mobile/lib/utils/ingredientParser.ts
+++ b/mobile/lib/utils/ingredientParser.ts
@@ -96,6 +96,8 @@ const UNITS = new Set([
   'handfuls',
   'pinch',
   'pinches',
+  'knippe',
+  'knippen',
   // Swedish units
   'msk',
   'tsk',


### PR DESCRIPTION
## Summary
- show the exact recipe-generated items hidden by Items at Home in the grocery stats help popup
- keep manually added grocery items visible while still hiding generated items that exactly match normalized pantry entries
- normalize Swedish garnish ingredients like `knippe grön sparris` so grocery generation keeps those items

## Testing
- cd /Users/caterina.bonazzi/git/meal-planner/mobile && pnpm vitest run lib/utils/__tests__/groceryAggregator.test.ts lib/hooks/__tests__/useGroceryScreen.test.ts components/__tests__/StatsCard.test.tsx lib/utils/__tests__/ingredientParser.test.ts
- cd /Users/caterina.bonazzi/git/meal-planner/mobile && pnpm vitest run lib/__tests__/settings-context.test.tsx lib/hooks/__tests__/useGroceryScreen.test.ts