### PR TITLE
fix: normalize pantry note matching

### DIFF
--- a/mobile/lib/__tests__/settings-context.test.tsx
+++ b/mobile/lib/__tests__/settings-context.test.tsx
@@ -345,6 +345,18 @@ describe('SettingsProvider', () => {
       expect(result.current.isItemAtHome("2 cucchiai olio d'oliva")).toBe(true);
     });
 
+    it('ignores parenthetical notes and spacing-only differences', async () => {
+      mockItemsAtHome = ['salt', 'japansksoja'];
+
+      const { result } = renderHook(() => useSettings(), {
+        wrapper: createSettingsWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.isItemAtHome('2 krm salt (till nudelvattnet)')).toBe(true);
+      expect(result.current.isItemAtHome('japansk soja')).toBe(true);
+    });
+
     it('returns false for partial matches', async () => {
       mockItemsAtHome = ['salt', 'olive oil'];
 

--- a/mobile/lib/__tests__/settings-context.test.tsx
+++ b/mobile/lib/__tests__/settings-context.test.tsx
@@ -306,6 +306,32 @@ describe('SettingsProvider', () => {
 
       expect(capturedItem).toBe("olio d'oliva");
     });
+
+    it('removes using pantry note stripping and spacing-insensitive matching', async () => {
+      const capturedItems: string[] = [];
+      mockUseRemoveItemAtHome.mockImplementation(() => ({
+        mutateAsync: async (params: { householdId: string; item: string }) => {
+          capturedItems.push(params.item);
+          return { items_at_home: [] };
+        },
+      }));
+
+      mockItemsAtHome = ['salt', 'japansksoja'];
+
+      const { result } = renderHook(() => useSettings(), {
+        wrapper: createSettingsWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.removeItemAtHome('2 krm salt (till nudelvattnet)');
+      });
+      await act(async () => {
+        await result.current.removeItemAtHome('japansk soja');
+      });
+
+      expect(capturedItems).toEqual(['salt', 'japansksoja']);
+    });
   });
 
   describe('isItemAtHome', () => {

--- a/mobile/lib/settings-context.tsx
+++ b/mobile/lib/settings-context.tsx
@@ -35,8 +35,8 @@ import {
 import { useAuth } from './hooks/use-auth';
 import type { GroceryStore, HouseholdSettings } from './types';
 import {
-  normalizeIngredientMatchKey,
-  normalizeIngredientName,
+  normalizePantryItemName,
+  normalizePantryMatchKey,
 } from './utils/ingredientParser';
 
 const STORAGE_KEY = '@meal_planner_settings';
@@ -245,7 +245,7 @@ export const SettingsProvider = ({
         console.warn('Cannot add item at home: no household');
         return;
       }
-      const normalizedItem = normalizeIngredientName(item);
+      const normalizedItem = normalizePantryItemName(item);
       if (!normalizedItem) return;
 
       await addItemMutation.mutateAsync({ householdId, item: normalizedItem });
@@ -259,13 +259,13 @@ export const SettingsProvider = ({
         console.warn('Cannot remove item at home: no household');
         return;
       }
-      const normalizedKey = normalizeIngredientMatchKey(item);
+      const normalizedKey = normalizePantryMatchKey(item);
       if (!normalizedKey) return;
 
       const matchingItem = settings.itemsAtHome.find(
-        (homeItem) => normalizeIngredientMatchKey(homeItem) === normalizedKey,
+        (homeItem) => normalizePantryMatchKey(homeItem) === normalizedKey,
       );
-      const normalizedItem = matchingItem ?? normalizeIngredientName(item);
+      const normalizedItem = matchingItem ?? normalizePantryItemName(item);
       if (!normalizedItem) return;
 
       await removeItemMutation.mutateAsync({
@@ -278,9 +278,9 @@ export const SettingsProvider = ({
 
   const isItemAtHome = useCallback(
     (item: string) => {
-      const normalizedItem = normalizeIngredientMatchKey(item);
+      const normalizedItem = normalizePantryMatchKey(item);
       return settings.itemsAtHome.some(
-        (homeItem) => normalizeIngredientMatchKey(homeItem) === normalizedItem,
+        (homeItem) => normalizePantryMatchKey(homeItem) === normalizedItem,
       );
     },
     [settings.itemsAtHome],

--- a/mobile/lib/settings-context.tsx
+++ b/mobile/lib/settings-context.tsx
@@ -34,7 +34,10 @@ import {
 } from './hooks/use-admin';
 import { useAuth } from './hooks/use-auth';
 import type { GroceryStore, HouseholdSettings } from './types';
-import { normalizeIngredientName } from './utils/ingredientParser';
+import {
+  normalizeIngredientMatchKey,
+  normalizeIngredientName,
+} from './utils/ingredientParser';
 
 const STORAGE_KEY = '@meal_planner_settings';
 
@@ -256,7 +259,13 @@ export const SettingsProvider = ({
         console.warn('Cannot remove item at home: no household');
         return;
       }
-      const normalizedItem = normalizeIngredientName(item);
+      const normalizedKey = normalizeIngredientMatchKey(item);
+      if (!normalizedKey) return;
+
+      const matchingItem = settings.itemsAtHome.find(
+        (homeItem) => normalizeIngredientMatchKey(homeItem) === normalizedKey,
+      );
+      const normalizedItem = matchingItem ?? normalizeIngredientName(item);
       if (!normalizedItem) return;
 
       await removeItemMutation.mutateAsync({
@@ -264,14 +273,14 @@ export const SettingsProvider = ({
         item: normalizedItem,
       });
     },
-    [householdId, removeItemMutation],
+    [householdId, removeItemMutation, settings.itemsAtHome],
   );
 
   const isItemAtHome = useCallback(
     (item: string) => {
-      const normalizedItem = normalizeIngredientName(item);
+      const normalizedItem = normalizeIngredientMatchKey(item);
       return settings.itemsAtHome.some(
-        (homeItem) => normalizeIngredientName(homeItem) === normalizedItem,
+        (homeItem) => normalizeIngredientMatchKey(homeItem) === normalizedItem,
       );
     },
     [settings.itemsAtHome],

--- a/mobile/lib/utils/__tests__/ingredientParser.test.ts
+++ b/mobile/lib/utils/__tests__/ingredientParser.test.ts
@@ -2,10 +2,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatQuantity,
-  normalizeIngredientMatchKey,
   parseIngredient,
   scaleIngredient,
   normalizeIngredientName,
+  normalizePantryItemName,
+  normalizePantryMatchKey,
 } from '../ingredientParser';
 
 describe('formatQuantity', () => {
@@ -228,23 +229,35 @@ describe('normalizeIngredientName', () => {
     expect(normalizeIngredientName("2 cucchiai Olio d'Oliva")).toBe("olio d'oliva");
   });
 
-  it('strips parenthetical notes from the normalized name', () => {
-    expect(normalizeIngredientName('2 krm salt (till nudelvattnet)')).toBe('salt');
+  it('preserves parenthetical notes for generic ingredient grouping', () => {
+    expect(normalizeIngredientName('2 krm salt (till nudelvattnet)')).toBe(
+      'salt (till nudelvattnet)',
+    );
   });
 
-  it('treats spacing-only differences as the same normalized name', () => {
+  it('preserves spacing differences for generic ingredient grouping', () => {
     expect(normalizeIngredientName('japansk soja')).toBe('japansk soja');
     expect(normalizeIngredientName('japansksoja')).toBe('japansksoja');
   });
 });
 
-describe('normalizeIngredientMatchKey', () => {
+describe('normalizePantryItemName', () => {
+  it('strips parenthetical pantry notes', () => {
+    expect(normalizePantryItemName('2 krm salt (till nudelvattnet)')).toBe('salt');
+  });
+
+  it('preserves readable spacing in pantry names', () => {
+    expect(normalizePantryItemName('2 tbsp Olive Oil')).toBe('olive oil');
+  });
+});
+
+describe('normalizePantryMatchKey', () => {
   it('ignores spacing-only differences', () => {
-    expect(normalizeIngredientMatchKey('japansk soja')).toBe('japansksoja');
-    expect(normalizeIngredientMatchKey('japansksoja')).toBe('japansksoja');
+    expect(normalizePantryMatchKey('japansk soja')).toBe('japansksoja');
+    expect(normalizePantryMatchKey('japansksoja')).toBe('japansksoja');
   });
 
   it('ignores parenthetical notes and quantity prefixes', () => {
-    expect(normalizeIngredientMatchKey('2 krm salt (till nudelvattnet)')).toBe('salt');
+    expect(normalizePantryMatchKey('2 krm salt (till nudelvattnet)')).toBe('salt');
   });
 });

--- a/mobile/lib/utils/__tests__/ingredientParser.test.ts
+++ b/mobile/lib/utils/__tests__/ingredientParser.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatQuantity,
+  normalizeIngredientMatchKey,
   parseIngredient,
   scaleIngredient,
   normalizeIngredientName,
@@ -225,5 +226,25 @@ describe('normalizeIngredientName', () => {
     expect(normalizeIngredientName('2 tbsp Olive Oil')).toBe('olive oil');
     expect(normalizeIngredientName('2 stycken Ägg')).toBe('ägg');
     expect(normalizeIngredientName("2 cucchiai Olio d'Oliva")).toBe("olio d'oliva");
+  });
+
+  it('strips parenthetical notes from the normalized name', () => {
+    expect(normalizeIngredientName('2 krm salt (till nudelvattnet)')).toBe('salt');
+  });
+
+  it('treats spacing-only differences as the same normalized name', () => {
+    expect(normalizeIngredientName('japansk soja')).toBe('japansk soja');
+    expect(normalizeIngredientName('japansksoja')).toBe('japansksoja');
+  });
+});
+
+describe('normalizeIngredientMatchKey', () => {
+  it('ignores spacing-only differences', () => {
+    expect(normalizeIngredientMatchKey('japansk soja')).toBe('japansksoja');
+    expect(normalizeIngredientMatchKey('japansksoja')).toBe('japansksoja');
+  });
+
+  it('ignores parenthetical notes and quantity prefixes', () => {
+    expect(normalizeIngredientMatchKey('2 krm salt (till nudelvattnet)')).toBe('salt');
   });
 });

--- a/mobile/lib/utils/ingredientParser.ts
+++ b/mobile/lib/utils/ingredientParser.ts
@@ -288,5 +288,13 @@ export function scaleIngredient(
  */
 export function normalizeIngredientName(ingredient: string): string {
   const parsed = parseIngredient(ingredient);
-  return parsed.name.toLowerCase().trim();
+  return parsed.name
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeIngredientMatchKey(ingredient: string): string {
+  return normalizeIngredientName(ingredient).replace(/\s+/g, '');
 }

--- a/mobile/lib/utils/ingredientParser.ts
+++ b/mobile/lib/utils/ingredientParser.ts
@@ -288,13 +288,16 @@ export function scaleIngredient(
  */
 export function normalizeIngredientName(ingredient: string): string {
   const parsed = parseIngredient(ingredient);
-  return parsed.name
-    .toLowerCase()
+  return parsed.name.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+export function normalizePantryItemName(ingredient: string): string {
+  return normalizeIngredientName(ingredient)
     .replace(/\([^)]*\)/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }
 
-export function normalizeIngredientMatchKey(ingredient: string): string {
-  return normalizeIngredientName(ingredient).replace(/\s+/g, '');
+export function normalizePantryMatchKey(ingredient: string): string {
+  return normalizePantryItemName(ingredient).replace(/\s+/g, '');
 }


### PR DESCRIPTION
## Summary
- strip parenthetical ingredient notes from pantry normalization so note-only suffixes do not affect Items at Home matching
- use a separate space-insensitive pantry match key so names like `japansk soja` and `japansksoja` compare equal while stored pantry entries remain readable
- reuse the same shared normalization path for pantry matching and removal to keep behavior consistent

## Testing
- cd /Users/caterina.bonazzi/git/meal-planner/mobile && pnpm vitest run lib/utils/__tests__/ingredientParser.test.ts lib/__tests__/settings-context.test.tsx