### PR TITLE
chore: pin pnpm via packageManager field to fix Renovate lockfile drift

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -78,5 +78,6 @@
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0"
     }
   },
-  "private": true
+  "private": true,
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }


### PR DESCRIPTION
## Problem

Renovate dependency PRs (e.g. #501) fail CI at the pnpm install --frozen-lockfile step in the test-mobile and prek jobs. Self-hosted Renovate bumps mobile/package.json but does not regenerate mobile/pnpm-lock.yaml, so the manifest and lockfile drift and the frozen install refuses to proceed.

Root cause: mobile/package.json had no packageManager field, so Renovate's containerbase could not reliably resolve/install pnpm to run the post-update lockfile refresh.

## Fix

Add a packageManager field pinned to the exact pnpm version currently in use, including a +sha512 integrity hash (generated via corepack use pnpm@10.28.2):

- Lets Renovate's containerbase install the matching pnpm and regenerate the lockfile on dependency PRs.
- The integrity hash means Corepack verifies the pnpm tarball before executing it, mitigating supply-chain tampering of the pnpm binary.
- CI stays strict (--frozen-lockfile), so real lockfile drift is still caught.

## Notes

- The +sha512 hash protects the pnpm binary download; project dependencies remain protected by the existing hashes in pnpm-lock.yaml.
- CI's npm install -g pnpm@10 step does not consume the hash, but Renovate's containerbase and local Corepack-enabled dev do.
- Existing stuck Renovate PRs should regenerate their lockfiles once they rebase onto main.
